### PR TITLE
Fix target validation to also allow for case targets

### DIFF
--- a/code/validation/functions_plausibility.R
+++ b/code/validation/functions_plausibility.R
@@ -177,6 +177,10 @@ verify_targets <- function(entry){
     paste(-1:130, "day ahead cum death"),
     paste(-1:20, "wk ahead inc death"),
     paste(-1:20, "wk ahead cum death"),
+    paste(-1:130, "day ahead inc case"),
+    paste(-1:130, "day ahead cum case"),
+    paste(-1:20, "wk ahead inc case"),
+    paste(-1:20, "wk ahead cum case"),
     paste(-1:130, "day ahead inc hosp")
   )
   targets_in_entry <- unique(entry$target)


### PR DESCRIPTION
While running `validate_file` on my submission, I noticed that cases were not allowed as targets; this commit adds them to the validation.