### PR TITLE
 Forecast Death/Case/ICU for Germany + Saxony LeipzigIMISE-SECIR on 2020-12-07

### DIFF
--- a/data-processed/LeipzigIMISE-SECIR/2020-12-06-Germany-LeipzigIMISE-SECIR-ICU.csv
+++ b/data-processed/LeipzigIMISE-SECIR/2020-12-06-Germany-LeipzigIMISE-SECIR-ICU.csv
@@ -1,0 +1,943 @@
+"forecast_date","target","target_end_date","location","location_name","type","quantile","value"
+2020-12-06,"-1 day ahead curr ICU",2020-12-05,"GM","Germany","observed",NA,4051
+2020-12-06,"0 day ahead curr ICU",2020-12-06,"GM","Germany","observed",NA,4108
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","point",NA,4124.6347187
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","point",NA,4135.9984151
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","point",NA,4144.7087966
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","point",NA,4148.1152073
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","point",NA,4147.591785
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","point",NA,4143.575755
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","point",NA,4145.4902098
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","point",NA,4135.2081734
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","point",NA,4136.132819
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","point",NA,4133.7981474
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","point",NA,4126.6671928
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","point",NA,4126.7004634
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","point",NA,4125.91063
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","point",NA,4125.4221174
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","point",NA,4122.3324927
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","point",NA,4126.7034682
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","point",NA,4117.7477986
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","point",NA,4127.0041959
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","point",NA,4121.8125754
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","point",NA,4126.0408766
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","point",NA,4127.955946
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","point",NA,4133.8007886
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","point",NA,4129.4450229
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","point",NA,4132.8854405
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","point",NA,4133.5025548
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","point",NA,4132.3702098
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","point",NA,4119.4276081
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","point",NA,4117.3500359
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","point",NA,4107.7266891
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","point",NA,4102.8603413
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","point",NA,4097.933505
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.01",3826.8678871
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.01",3799.8558802
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.01",3775.9511861
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.01",3749.8515892
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.01",3725.9975615
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.01",3696.9843034
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.01",3672.2520163
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.01",3652.3313316
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.01",3629.8409426
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.01",3610.5547649
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.01",3587.8413941
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.01",3567.4329596
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.01",3551.5171038
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.01",3534.5771078
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.01",3519.6635912
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.01",3506.3288246
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.01",3488.1908234
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.01",3473.3346986
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.01",3458.7328121
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.01",3447.0638735
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.01",3432.9862012
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.01",3420.7498989
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.01",3405.0818132
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.01",3390.7431273
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.01",3375.0910713
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.01",3361.9259307
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.01",3347.7283398
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.01",3335.4123749
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.01",3316.8526798
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.01",3300.9895213
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.01",3290.8285025
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.025",3866.294077
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.025",3841.4650609
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.025",3817.9836853
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.025",3792.2605926
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.025",3768.6931985
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.025",3742.0121717
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.025",3718.3232009
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.025",3695.4297506
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.025",3674.8080847
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.025",3655.8619745
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.025",3634.3109531
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.025",3614.2258302
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.025",3599.8874381
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.025",3580.6134713
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.025",3567.0968215
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.025",3554.427919
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.025",3536.1834202
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.025",3523.3393017
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.025",3510.4095912
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.025",3497.6813209
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.025",3485.8002296
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.025",3472.4481449
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.025",3460.0755738
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.025",3446.4296581
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.025",3433.4814364
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.025",3422.9129895
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.025",3410.4654404
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.025",3396.9292053
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.025",3383.9625027
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.025",3369.3173625
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.025",3358.1211079
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.05",3902.7526777
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.05",3879.3436348
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.05",3855.4465306
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.05",3831.0424029
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.05",3807.6909216
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.05",3781.9254072
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.05",3760.5066137
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.05",3738.3463224
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.05",3717.5648423
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.05",3698.7017306
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.05",3678.6830427
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.05",3660.1128424
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.05",3643.8613983
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.05",3626.4997633
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.05",3612.8305586
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.05",3599.5608049
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.05",3582.6107131
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.05",3572.6875841
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.05",3558.9188518
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.05",3544.8153185
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.05",3535.8687049
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.05",3520.9223545
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.05",3510.5338252
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.05",3500.2226191
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.05",3486.5921499
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.05",3477.2985854
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.05",3467.3076914
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.05",3454.0669583
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.05",3441.9345381
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.05",3429.4365982
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.05",3418.7295535
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.1",3947.1139153
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.1",3925.7639215
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.1",3903.1188608
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.1",3880.4231942
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.1",3857.7286042
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.1",3832.3061154
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.1",3813.4239917
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.1",3791.2618858
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.1",3772.8141368
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.1",3753.7185953
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.1",3734.976214
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.1",3717.7775583
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.1",3703.0144878
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.1",3686.3478777
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.1",3672.7915437
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.1",3660.0353161
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.1",3644.4605727
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.1",3634.7660342
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.1",3621.8512457
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.1",3609.7244157
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.1",3599.9838788
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.1",3588.4023058
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.1",3577.6215775
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.1",3568.0044841
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.1",3557.3855938
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.1",3548.6627021
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.1",3537.7837853
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.1",3526.4234716
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.1",3516.095147
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.1",3505.3111277
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.1",3496.9832508
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.15",3978.6742818
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.15",3959.5433412
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.15",3938.0936895
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.15",3916.5696237
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.15",3894.6768473
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.15",3871.1428966
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.15",3853.1187522
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.15",3832.7307647
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.15",3814.3250457
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.15",3796.4729269
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.15",3778.6359004
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.15",3763.8477055
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.15",3749.0276288
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.15",3733.0912168
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.15",3721.1408231
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.15",3709.4786418
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.15",3694.4451049
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.15",3685.0039889
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.15",3672.5059684
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.15",3660.6954122
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.15",3652.6089608
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.15",3641.597968
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.15",3632.0591201
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.15",3623.513687
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.15",3613.5556749
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.15",3606.252698
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.15",3596.6087724
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.15",3584.7555728
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.15",3575.7418511
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.15",3566.0579036
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.15",3558.4143786
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.2",4004.4620393
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.2",3988.087827
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.2",3968.2688244
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.2",3948.9103753
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.2",3927.508781
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.2",3905.5499013
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.2",3889.5537636
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.2",3869.8017954
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.2",3852.7070327
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.2",3836.0905563
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.2",3820.326852
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.2",3805.4477424
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.2",3792.9935198
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.2",3777.5986802
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.2",3766.8700741
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.2",3755.1665247
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.2",3741.1237396
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.2",3733.3305414
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.2",3721.7264436
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.2",3712.3300965
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.2",3705.0939217
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.2",3695.221172
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.2",3686.4962449
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.2",3678.6525926
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.2",3670.1273388
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.2",3664.2367199
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.2",3655.3038447
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.2",3643.1903861
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.2",3635.2138305
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.2",3625.9631558
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.2",3619.0843651
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.25",4027.6580694
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.25",4015.1498746
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.25",3996.4478735
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.25",3978.3259703
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.25",3958.2921212
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.25",3938.1296725
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.25",3924.0302246
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.25",3905.159183
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.25",3890.3344458
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.25",3875.5475825
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.25",3860.3583102
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.25",3848.6565043
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.25",3837.4078962
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.25",3824.6019821
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.25",3813.4409893
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.25",3804.3275208
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.25",3791.1632685
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.25",3785.1846828
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.25",3776.3663973
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.25",3767.4281697
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.25",3762.0651626
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.25",3753.4618739
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.25",3746.6663421
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.25",3740.8775136
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.25",3733.349052
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.25",3728.5339806
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.25",3720.5717056
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.25",3708.2332356
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.25",3700.6280607
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.25",3691.7512074
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.25",3686.5910426
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.3",4049.3661703
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.3",4039.9973822
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.3",4023.8611108
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.3",4007.8142385
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.3",3990.3160034
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.3",3972.012849
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.3",3959.3776621
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.3",3941.4380044
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.3",3929.0319243
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.3",3916.3558805
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.3",3903.1514568
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.3",3893.770871
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.3",3884.2857744
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.3",3873.0556921
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.3",3864.2867507
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.3",3857.7187107
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.3",3845.474185
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.3",3843.0786115
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.3",3836.3095125
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.3",3830.4474516
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.3",3825.8117449
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.3",3818.983162
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.3",3811.8679938
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.3",3810.2659668
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.3",3804.9720472
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.3",3802.3595354
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.3",3794.7013516
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.3",3783.0186846
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.3",3777.4745532
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.3",3771.9289698
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.3",3766.9062657
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.35",4069.6265652
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.35",4064.5659908
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.35",4052.4266753
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.35",4038.3055335
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.35",4023.0420122
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.35",4007.9120001
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.35",3997.2019076
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.35",3980.3234689
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.35",3970.7823908
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.35",3960.4427483
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.35",3949.5971308
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.35",3942.9319696
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.35",3935.1801037
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.35",3926.7649454
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.35",3919.5187391
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.35",3916.9664208
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.35",3905.5987558
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.35",3907.1428706
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.35",3901.2352344
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.35",3896.8872952
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.35",3895.742294
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.35",3893.2324379
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.35",3884.8135362
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.35",3886.0099985
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.35",3883.351009
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.35",3882.3423596
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.35",3875.1947988
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.35",3865.4182783
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.35",3861.1295322
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.35",3857.8421989
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.35",3854.0570498
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.4",4088.8356772
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.4",4088.786292
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.4",4082.6563412
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.4",4071.4990904
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.4",4058.9815587
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.4",4046.3375427
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.4",4037.5445688
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.4",4023.9076507
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.4",4017.3868855
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.4",4008.7132502
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.4",4000.0168176
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.4",3995.4999234
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.4",3989.9194216
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.4",3985.8707488
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.4",3980.8208826
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.4",3979.8201597
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.4",3970.584137
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.4",3974.8382664
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.4",3971.3551438
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.4",3969.4563596
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.4",3969.9728811
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.4",3970.4210609
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.4",3963.8952995
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.4",3965.0053701
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.4",3966.1573902
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.4",3967.4847594
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.4",3957.1218174
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.4",3952.5318088
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.4",3949.0798173
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.4",3945.8884345
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.4",3940.92014
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.45",4106.7897758
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.45",4112.3297511
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.45",4113.3446566
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.45",4107.9844976
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.45",4100.3600724
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.45",4090.7751258
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.45",4085.8573226
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.45",4074.2592807
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.45",4070.6173549
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.45",4064.327301
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.45",4057.012372
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.45",4054.5475662
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.45",4051.7060707
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.45",4049.3063711
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.45",4046.1332361
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.45",4048.6726716
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.45",4040.0716377
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.45",4045.9014876
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.45",4041.5835241
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.45",4043.3441828
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.45",4045.4270223
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.45",4050.2515224
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.45",4043.6023169
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.45",4047.2987046
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.45",4049.9603502
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.45",4049.9486737
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.45",4039.0684028
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.45",4037.5917615
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.45",4030.7059409
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.45",4027.578064
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.45",4023.817136
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.5",4124.6347187
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.5",4135.9984151
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.5",4144.7087966
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.5",4148.1152073
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.5",4147.591785
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.5",4143.575755
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.5",4145.4902098
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.5",4135.2081734
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.5",4136.132819
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.5",4133.7981474
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.5",4126.6671928
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.5",4126.7004634
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.5",4125.91063
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.5",4125.4221174
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.5",4122.3324927
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.5",4126.7034682
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.5",4117.7477986
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.5",4127.0041959
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.5",4121.8125754
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.5",4126.0408766
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.5",4127.955946
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.5",4133.8007886
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.5",4129.4450229
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.5",4132.8854405
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.5",4133.5025548
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.5",4132.3702098
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.5",4119.4276081
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.5",4117.3500359
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.5",4107.7266891
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.5",4102.8603413
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.5",4097.933505
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.55",4141.916418
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.55",4158.7444894
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.55",4175.8778328
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.55",4189.9825742
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.55",4203.0753488
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.55",4210.4209718
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.55",4224.9128149
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.55",4223.4526287
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.55",4233.8952908
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.55",4241.2250783
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.55",4235.271074
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.55",4241.8032062
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.55",4245.5191175
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.55",4249.2500803
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.55",4240.763554
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.55",4248.9059882
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.55",4241.2721336
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.55",4243.8869916
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.55",4240.012953
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.55",4240.7297458
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.55",4237.6212385
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.55",4238.338814
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.55",4227.3134204
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.55",4228.8992029
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.55",4222.1747391
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.55",4216.7266478
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.55",4199.4554811
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.55",4191.5695031
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.55",4180.6591185
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.55",4173.4823974
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.55",4165.2372209
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.6",4159.4911358
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.6",4181.6495989
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.6",4206.1365499
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.6",4229.3006313
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.6",4253.7594616
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.6",4276.0782519
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.6",4304.6615394
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.6",4319.0910746
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.6",4339.8029488
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.6",4355.4342741
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.6",4367.786042
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.6",4378.0051885
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.6",4387.3430427
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.6",4393.9158211
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.6",4388.5921682
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.6",4397.9322136
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.6",4387.48646
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.6",4384.7104515
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.6",4375.6411529
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.6",4369.8858788
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.6",4355.9903573
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.6",4350.4324969
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.6",4331.2717811
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.6",4320.8483836
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.6",4311.1935165
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.6",4297.2725314
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.6",4277.6333811
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.6",4264.5652854
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.6",4250.4622945
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.6",4238.2817516
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.6",4228.6357785
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.65",4177.1774153
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.65",4204.1166874
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.65",4234.6997624
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.65",4265.159503
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.65",4297.2286545
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.65",4325.4265951
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.65",4357.3086923
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.65",4380.0417382
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.65",4403.0116788
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.65",4421.6341008
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.65",4438.1963515
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.65",4449.354403
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.65",4460.4479498
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.65",4468.6414762
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.65",4467.7783128
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.65",4474.2188213
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.65",4468.1387389
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.65",4464.511992
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.65",4457.8027408
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.65",4451.5867934
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.65",4437.2341151
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.65",4431.1351866
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.65",4413.0263846
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.65",4401.0764739
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.65",4386.263591
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.65",4369.7860558
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.65",4348.975006
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.65",4331.80935
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.65",4316.5901445
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.65",4301.7299707
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.65",4289.610376
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.7",4195.4465158
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.7",4227.0784522
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.7",4262.4150936
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.7",4297.7387327
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.7",4332.9384748
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.7",4365.2159598
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.7",4399.1149544
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.7",4424.73728
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.7",4450.0943055
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.7",4470.0697638
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.7",4487.9800455
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.7",4500.9521221
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.7",4512.4773905
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.7",4522.2167398
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.7",4522.5292369
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.7",4530.1061781
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.7",4527.3079819
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.7",4522.7813248
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.7",4518.9848576
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.7",4512.0619042
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.7",4501.4178904
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.7",4493.264752
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.7",4477.6130829
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.7",4467.9876856
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.7",4453.6686079
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.7",4435.7163235
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.7",4415.8249432
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.7",4399.5464364
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.7",4382.5978872
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.7",4364.7151562
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.7",4350.8334706
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.75",4215.6870436
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.75",4249.9229099
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.75",4289.5330373
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.75",4328.7046751
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.75",4365.8532237
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.75",4400.4281469
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.75",4435.6680165
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.75",4462.3698491
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.75",4488.815139
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.75",4509.5267564
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.75",4529.2990828
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.75",4544.8204954
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.75",4556.4917617
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.75",4566.2111383
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.75",4570.2502219
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.75",4576.5075432
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.75",4576.5765832
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.75",4574.9373382
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.75",4571.9297499
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.75",4565.5182293
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.75",4556.5644281
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.75",4550.2627117
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.75",4536.4640094
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.75",4527.8574737
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.75",4513.4753926
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.75",4497.3345764
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.75",4480.0281519
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.75",4463.7398704
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.75",4447.8244092
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.75",4428.8746595
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.75",4416.0836533
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.8",4236.0795513
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.8",4274.5021577
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.8",4317.5344543
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.8",4358.2462607
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.8",4397.9556209
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.8",4433.6172532
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.8",4469.7975309
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.8",4497.7629367
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.8",4525.5294303
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.8",4546.9661869
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.8",4568.925434
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.8",4585.4747227
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.8",4597.9331944
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.8",4610.1415651
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.8",4613.8215454
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.8",4621.9184367
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.8",4622.5171358
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.8",4622.5740799
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.8",4622.1291085
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.8",4616.1895835
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.8",4608.9863149
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.8",4603.8408595
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.8",4593.1241052
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.8",4585.7938383
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.8",4572.3139812
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.8",4557.4007978
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.8",4544.0658074
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.8",4527.782652
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.8",4513.8568405
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.8",4495.1714603
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.8",4483.2742532
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.85",4259.8764625
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.85",4301.6539319
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.85",4346.7445681
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.85",4390.4294995
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.85",4430.4887754
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.85",4467.984395
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.85",4504.8513184
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.85",4535.0227848
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.85",4562.7046725
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.85",4585.7751633
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.85",4608.8039151
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.85",4626.7041295
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.85",4640.2670479
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.85",4653.0730606
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.85",4659.1550562
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.85",4668.5885587
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.85",4670.5255634
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.85",4672.2205094
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.85",4671.6735302
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.85",4667.3214232
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.85",4665.1394033
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.85",4659.1441407
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.85",4651.2313912
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.85",4644.6857572
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.85",4632.5038667
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.85",4620.7470486
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.85",4609.0126239
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.85",4596.555613
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.85",4583.8070467
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.85",4566.9547915
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.85",4557.2811119
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.9",4289.1230588
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.9",4334.2231089
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.9",4381.0721577
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.9",4426.0602686
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.9",4468.4228429
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.9",4506.9079636
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.9",4544.6611321
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.9",4575.9437596
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.9",4604.9104708
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.9",4628.294307
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.9",4653.1469702
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.9",4671.509389
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.9",4687.4288505
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.9",4701.9076239
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.9",4709.5935865
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.9",4720.237104
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.9",4724.683856
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.9",4726.6218587
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.9",4727.7738842
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.9",4726.1587439
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.9",4725.9107806
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.9",4721.9836111
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.9",4715.2799605
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.9",4711.5088163
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.9",4700.4733707
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.9",4692.6784797
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.9",4684.3168025
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.9",4674.5506187
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.9",4663.8234765
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.9",4652.2742188
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.9",4644.9748586
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.95",4332.238002
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.95",4379.9803185
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.95",4428.9521813
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.95",4475.330062
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.95",4518.0323362
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.95",4560.3232647
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.95",4597.9044267
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.95",4630.8514233
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.95",4660.7388326
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.95",4686.3162136
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.95",4711.6308676
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.95",4731.3633137
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.95",4748.8225071
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.95",4766.1484968
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.95",4774.4228105
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.95",4787.2463117
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.95",4793.4137317
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.95",4801.236483
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.95",4804.3126813
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.95",4807.2641735
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.95",4809.9706625
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.95",4805.5423024
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.95",4805.2365928
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.95",4802.3441562
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.95",4797.715586
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.95",4795.9376304
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.95",4791.0683845
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.95",4785.039746
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.95",4778.8921569
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.95",4767.9261042
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.95",4766.9247388
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.975",4367.3488476
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.975",4417.219084
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.975",4468.2879685
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.975",4515.790135
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.975",4560.5788275
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.975",4602.8303367
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.975",4642.3552366
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.975",4675.1713264
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.975",4707.576262
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.975",4733.6251745
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.975",4759.2062774
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.975",4779.7581804
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.975",4799.2734664
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.975",4815.5388529
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.975",4826.457313
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.975",4842.5881435
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.975",4848.5791929
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.975",4861.6991195
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.975",4868.7615648
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.975",4874.6465494
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.975",4880.5388606
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.975",4881.5971074
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.975",4882.7559037
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.975",4887.2599507
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.975",4887.5668486
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.975",4886.0989292
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.975",4886.7446726
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.975",4888.68126
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.975",4883.6800432
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.975",4881.2081153
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.975",4885.9002356
+2020-12-06,"1 day ahead curr ICU",2020-12-07,"GM","Germany","quantile","0.99",4409.0720664
+2020-12-06,"2 day ahead curr ICU",2020-12-08,"GM","Germany","quantile","0.99",4459.4893724
+2020-12-06,"3 day ahead curr ICU",2020-12-09,"GM","Germany","quantile","0.99",4513.0543817
+2020-12-06,"4 day ahead curr ICU",2020-12-10,"GM","Germany","quantile","0.99",4560.5139099
+2020-12-06,"5 day ahead curr ICU",2020-12-11,"GM","Germany","quantile","0.99",4607.6459985
+2020-12-06,"6 day ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.99",4650.2380944
+2020-12-06,"7 day ahead curr ICU",2020-12-13,"GM","Germany","quantile","0.99",4691.1244634
+2020-12-06,"8 day ahead curr ICU",2020-12-14,"GM","Germany","quantile","0.99",4724.3019847
+2020-12-06,"9 day ahead curr ICU",2020-12-15,"GM","Germany","quantile","0.99",4757.6923722
+2020-12-06,"10 day ahead curr ICU",2020-12-16,"GM","Germany","quantile","0.99",4782.9775572
+2020-12-06,"11 day ahead curr ICU",2020-12-17,"GM","Germany","quantile","0.99",4811.2275068
+2020-12-06,"12 day ahead curr ICU",2020-12-18,"GM","Germany","quantile","0.99",4832.0206524
+2020-12-06,"13 day ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.99",4852.4645723
+2020-12-06,"14 day ahead curr ICU",2020-12-20,"GM","Germany","quantile","0.99",4870.0744047
+2020-12-06,"15 day ahead curr ICU",2020-12-21,"GM","Germany","quantile","0.99",4886.259084
+2020-12-06,"16 day ahead curr ICU",2020-12-22,"GM","Germany","quantile","0.99",4903.6025312
+2020-12-06,"17 day ahead curr ICU",2020-12-23,"GM","Germany","quantile","0.99",4913.4997277
+2020-12-06,"18 day ahead curr ICU",2020-12-24,"GM","Germany","quantile","0.99",4933.2875321
+2020-12-06,"19 day ahead curr ICU",2020-12-25,"GM","Germany","quantile","0.99",4942.5738876
+2020-12-06,"20 day ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.99",4954.1911169
+2020-12-06,"21 day ahead curr ICU",2020-12-27,"GM","Germany","quantile","0.99",4963.4443792
+2020-12-06,"22 day ahead curr ICU",2020-12-28,"GM","Germany","quantile","0.99",4980.0338712
+2020-12-06,"23 day ahead curr ICU",2020-12-29,"GM","Germany","quantile","0.99",4984.7822872
+2020-12-06,"24 day ahead curr ICU",2020-12-30,"GM","Germany","quantile","0.99",4992.1943409
+2020-12-06,"25 day ahead curr ICU",2020-12-31,"GM","Germany","quantile","0.99",5016.3449088
+2020-12-06,"26 day ahead curr ICU",2021-01-01,"GM","Germany","quantile","0.99",5018.9537995
+2020-12-06,"27 day ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.99",5026.5478476
+2020-12-06,"28 day ahead curr ICU",2021-01-03,"GM","Germany","quantile","0.99",5042.795045
+2020-12-06,"29 day ahead curr ICU",2021-01-04,"GM","Germany","quantile","0.99",5039.3755796
+2020-12-06,"30 day ahead curr ICU",2021-01-05,"GM","Germany","quantile","0.99",5057.2089417
+2020-12-06,"31 day ahead curr ICU",2021-01-06,"GM","Germany","quantile","0.99",5074.8445062
+2020-12-06,"-1 wk ahead curr ICU",2020-11-28,"GM","Germany","observed",NA,3888
+2020-12-06,"0 wk ahead curr ICU",2020-12-05,"GM","Germany","observed",NA,4051
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.01",3696.9843034
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.01",3551.5171038
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.01",3447.0638735
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.01",3347.7283398
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.025",3742.0121717
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.025",3599.8874381
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.025",3497.6813209
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.025",3410.4654404
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.05",3781.9254072
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.05",3643.8613983
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.05",3544.8153185
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.05",3467.3076914
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.1",3832.3061154
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.1",3703.0144878
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.1",3609.7244157
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.1",3537.7837853
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.15",3871.1428966
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.15",3749.0276288
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.15",3660.6954122
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.15",3596.6087724
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.2",3905.5499013
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.2",3792.9935198
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.2",3712.3300965
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.2",3655.3038447
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.25",3938.1296725
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.25",3837.4078962
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.25",3767.4281697
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.25",3720.5717056
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.3",3972.012849
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.3",3884.2857744
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.3",3830.4474516
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.3",3794.7013516
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.35",4007.9120001
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.35",3935.1801037
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.35",3896.8872952
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.35",3875.1947988
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.4",4046.3375427
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.4",3989.9194216
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.4",3969.4563596
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.4",3957.1218174
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.45",4090.7751258
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.45",4051.7060707
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.45",4043.3441828
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.45",4039.0684028
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","point",NA,4143.575755
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","point",NA,4125.91063
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","point",NA,4126.0408766
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","point",NA,4119.4276081
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.55",4210.4209718
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.55",4245.5191175
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.55",4240.7297458
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.55",4199.4554811
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.6",4276.0782519
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.6",4387.3430427
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.6",4369.8858788
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.6",4277.6333811
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.65",4325.4265951
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.65",4460.4479498
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.65",4451.5867934
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.65",4348.975006
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.7",4365.2159598
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.7",4512.4773905
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.7",4512.0619042
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.7",4415.8249432
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.75",4400.4281469
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.75",4556.4917617
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.75",4565.5182293
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.75",4480.0281519
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.8",4433.6172532
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.8",4597.9331944
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.8",4616.1895835
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.8",4544.0658074
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.85",4467.984395
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.85",4640.2670479
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.85",4667.3214232
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.85",4609.0126239
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.9",4506.9079636
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.9",4687.4288505
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.9",4726.1587439
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.9",4684.3168025
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.95",4560.3232647
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.95",4748.8225071
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.95",4807.2641735
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.95",4791.0683845
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.975",4602.8303367
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.975",4799.2734664
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.975",4874.6465494
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.975",4886.7446726
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.99",4650.2380944
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.99",4852.4645723
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.99",4954.1911169
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.99",5026.5478476
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM","Germany","quantile","0.5",4143.575755
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM","Germany","quantile","0.5",4125.91063
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM","Germany","quantile","0.5",4126.0408766
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM","Germany","quantile","0.5",4119.4276081
+2020-12-06,"-1 wk ahead curr ICU",2020-11-28,"GM13","Free State of Saxony","observed",NA,360
+2020-12-06,"0 wk ahead curr ICU",2020-12-05,"GM13","Free State of Saxony","observed",NA,415
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.01",412.9676418
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.01",446.9875722
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.01",528.0039272
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.01",636.7667232
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.025",422.0775746
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.025",460.6324177
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.025",543.472114
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.025",655.0436389
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.05",429.9862688
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.05",472.7301102
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.05",558.3352774
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.05",672.0879716
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.1",439.5072924
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.1",486.8164081
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.1",576.096146
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.1",692.3025943
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.15",446.0120807
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.15",496.7498415
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.15",588.8088989
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.15",706.3618884
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.2",451.3520273
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.2",504.8207235
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.2",598.9155856
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.2",718.0513192
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.25",456.1513029
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.25",511.7251093
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.25",607.632005
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.25",728.3494576
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.3",460.4359234
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.3",518.1834869
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.3",615.6750159
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.3",738.1073839
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.35",464.5738199
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.35",524.4652165
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.35",623.3497593
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.35",747.5349266
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.4",468.5617464
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.4",530.7615538
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.4",631.2476334
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.4",756.9178317
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.45",472.5672015
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.45",536.8865121
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.45",639.4684636
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.45",766.8077534
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","point",NA,476.4929226
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","point",NA,543.4369806
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","point",NA,647.8670072
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","point",NA,777.2672375
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.55",480.5901628
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.55",550.4146206
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.55",656.9023487
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.55",788.3665217
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.6",484.6928005
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.6",557.604823
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.6",666.7690023
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.6",800.2909342
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.65",489.0261333
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.65",565.3161889
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.65",677.2311184
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.65",813.3811091
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.7",493.703822
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.7",573.429921
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.7",688.8130102
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.7",827.7522056
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.75",498.886011
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.75",582.225433
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.75",701.3177887
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.75",843.3514951
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.8",504.7038824
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.8",592.065549
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.8",715.2994948
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.8",860.8189433
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.85",511.2334225
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.85",603.7603849
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.85",731.3493602
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.85",881.3450825
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.9",519.4424182
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.9",617.8337437
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.9",750.6061325
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.9",906.2871462
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.95",531.9525961
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.95",636.7673378
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.95",776.0563249
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.95",938.4861873
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.975",542.0362461
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.975",651.0072064
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.975",794.6371348
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.975",962.5338815
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.99",553.0648001
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.99",666.8432876
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.99",814.2507294
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.99",986.6553608
+2020-12-06,"1 wk ahead curr ICU",2020-12-12,"GM13","Free State of Saxony","quantile","0.5",476.4929226
+2020-12-06,"2 wk ahead curr ICU",2020-12-19,"GM13","Free State of Saxony","quantile","0.5",543.4369806
+2020-12-06,"3 wk ahead curr ICU",2020-12-26,"GM13","Free State of Saxony","quantile","0.5",647.8670072
+2020-12-06,"4 wk ahead curr ICU",2021-01-02,"GM13","Free State of Saxony","quantile","0.5",777.2672375

--- a/data-processed/LeipzigIMISE-SECIR/2020-12-07-Germany-LeipzigIMISE-SECIR-case.csv
+++ b/data-processed/LeipzigIMISE-SECIR/2020-12-07-Germany-LeipzigIMISE-SECIR-case.csv
@@ -1,0 +1,1837 @@
+"forecast_date","target","target_end_date","location","location_name","type","quantile","value"
+2020-12-07,"-1 day ahead inc case",2020-12-06,"GM","Germany","observed",NA,17767
+2020-12-07,"0 day ahead inc case",2020-12-07,"GM","Germany","observed",NA,12332
+2020-12-07,"-1 day ahead cum case",2020-12-06,"GM","Germany","observed",NA,1171323
+2020-12-07,"0 day ahead cum case",2020-12-07,"GM","Germany","observed",NA,1183655
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","point",NA,12333.2878231
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","point",NA,12333.7615068
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","point",NA,12333.7147506
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","point",NA,12320.5892401
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","point",NA,12315.1348537
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","point",NA,12299.9898898
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","point",NA,12290.854307
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","point",NA,12278.6279246
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","point",NA,12271.0670317
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","point",NA,12248.6640888
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","point",NA,12233.7101592
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","point",NA,12227.4463728
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","point",NA,12195.88078
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","point",NA,12163.1038968
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","point",NA,12151.5235197
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","point",NA,12130.7023282
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","point",NA,12105.365325
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","point",NA,12071.1480322
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","point",NA,12052.2392274
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","point",NA,12008.62297
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","point",NA,11983.67848
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","point",NA,11933.5792896
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","point",NA,11914.1761473
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","point",NA,11866.8831585
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","point",NA,11828.8061003
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","point",NA,11788.3651258
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","point",NA,11763.4167939
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","point",NA,11706.5312323
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","point",NA,11663.7150364
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","point",NA,11624.7794531
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.01",9083.7914789
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.01",9061.8859798
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.01",9040.9466088
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.01",9026.4758133
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.01",8979.2455178
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.01",8993.8668683
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.01",8933.8249295
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.01",8913.9679339
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.01",8930.2979503
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.01",8839.8420707
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.01",8841.0053949
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.01",8777.9971968
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.01",8746.9103374
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.01",8725.4672189
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.01",8650.1467757
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.01",8622.0780925
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.01",8526.5887869
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.01",8505.4480907
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.01",8446.4234635
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.01",8386.6527111
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.01",8319.4431126
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.01",8265.9299031
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.01",8189.885581
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.01",8154.9030715
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.01",8118.8965065
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.01",8033.4127645
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.01",7985.0270785
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.01",7898.4403266
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.01",7860.7708287
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.01",7807.3821473
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.025",9569.1649781
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.025",9544.7859543
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.025",9529.0035318
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.025",9508.7442877
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.025",9486.6197703
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.025",9470.6285196
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.025",9449.5133746
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.025",9422.2375635
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.025",9402.829518
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.025",9345.419336
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.025",9310.4406364
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.025",9278.8502443
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.025",9244.0617916
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.025",9204.6469286
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.025",9168.5077216
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.025",9115.8676559
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.025",9032.073079
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.025",9015.1494917
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.025",8954.4053592
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.025",8900.0825916
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.025",8850.225746
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.025",8789.3539184
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.025",8728.2487551
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.025",8684.458565
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.025",8621.9161812
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.025",8548.4090152
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.025",8511.5813139
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.025",8415.8045904
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.025",8386.500264
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.025",8318.7924887
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.05",9986.0262872
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.05",9963.7032353
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.05",9956.2455689
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.05",9923.885853
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.05",9923.889964
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.05",9901.3556242
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.05",9882.7505991
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.05",9862.9177297
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.05",9842.8125533
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.05",9789.932574
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.05",9760.0555371
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.05",9721.7777791
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.05",9691.6981524
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.05",9653.2577567
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.05",9609.5287466
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.05",9551.3443143
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.05",9497.3029357
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.05",9471.6434535
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.05",9428.6776426
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.05",9349.7054988
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.05",9313.2970034
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.05",9255.3776739
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.05",9196.8605891
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.05",9148.4850612
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.05",9082.0402996
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.05",9029.5823317
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.05",8990.0863098
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.05",8903.9293071
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.05",8854.7080995
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.05",8798.4606765
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.1",10482.0741294
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.1",10466.9396702
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.1",10464.0865316
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.1",10437.8319943
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.1",10429.3236011
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.1",10405.4973657
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.1",10393.3999661
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.1",10371.1396198
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.1",10343.7840402
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.1",10312.4417467
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.1",10285.7982022
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.1",10238.0336244
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.1",10214.6072467
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.1",10176.2456313
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.1",10141.9116242
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.1",10100.6343614
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.1",10050.4085064
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.1",10016.5549982
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.1",9977.6636472
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.1",9908.1735189
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.1",9876.3840833
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.1",9806.9592481
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.1",9764.6889714
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.1",9709.557237
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.1",9653.4758555
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.1",9583.4837945
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.1",9554.1673068
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.1",9487.0351906
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.1",9430.3725034
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.1",9363.9295172
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.15",10821.2637945
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.15",10809.0689229
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.15",10809.6682706
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.15",10787.6980101
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.15",10779.7452806
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.15",10754.6016801
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.15",10739.6974504
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.15",10721.2258281
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.15",10700.1082861
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.15",10661.300567
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.15",10638.9031342
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.15",10613.3795278
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.15",10575.8059376
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.15",10547.1552004
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.15",10502.9334532
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.15",10468.5758084
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.15",10420.4798377
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.15",10390.062981
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.15",10356.4029681
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.15",10295.0900993
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.15",10269.7179168
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.15",10190.7725051
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.15",10160.204621
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.15",10105.3788522
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.15",10042.2672038
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.15",9993.3014747
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.15",9949.6584863
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.15",9884.7355042
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.15",9838.4114292
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.15",9770.395925
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.2",11094.2659133
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.2",11090.9530861
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.2",11094.033678
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.2",11068.5211185
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.2",11056.0400576
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.2",11044.3274303
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.2",11025.2891578
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.2",11000.5758394
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.2",10987.5504098
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.2",10945.0771034
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.2",10930.77674
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.2",10905.0428462
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.2",10866.6346156
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.2",10841.5768258
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.2",10798.4975592
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.2",10774.3939478
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.2",10736.8231621
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.2",10692.5076762
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.2",10663.1534095
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.2",10600.665872
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.2",10580.1183315
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.2",10503.8625955
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.2",10473.1349022
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.2",10416.7775509
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.2",10362.8274951
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.2",10309.4417159
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.2",10268.770829
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.2",10216.776561
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.2",10171.2013366
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.2",10103.5335313
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.25",11335.0874684
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.25",11332.8138988
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.25",11333.8944996
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.25",11310.01941
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.25",11301.2902597
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.25",11288.0747732
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.25",11268.3135044
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.25",11250.5500513
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.25",11233.8116482
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.25",11198.2904279
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.25",11185.7543561
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.25",11158.2465344
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.25",11128.8159988
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.25",11096.331144
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.25",11066.1127169
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.25",11034.7669534
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.25",11000.7239495
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.25",10958.3015437
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.25",10929.5541492
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.25",10868.2652061
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.25",10849.5964886
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.25",10784.680671
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.25",10757.9280137
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.25",10692.3720503
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.25",10651.0602241
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.25",10595.1615258
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.25",10560.4598111
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.25",10505.4471523
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.25",10455.3061265
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.25",10393.0952099
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.3",11556.5563305
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.3",11549.1929964
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.3",11546.4263357
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.3",11528.1645926
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.3",11523.7475532
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.3",11511.6519061
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.3",11490.4432786
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.3",11472.7545608
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.3",11460.5487845
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.3",11432.5504717
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.3",11415.0916328
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.3",11392.7939802
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.3",11361.4318528
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.3",11328.9907396
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.3",11302.5426823
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.3",11274.0313125
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.3",11243.6345818
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.3",11203.3891408
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.3",11176.6679632
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.3",11117.0288722
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.3",11098.6616629
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.3",11034.3642851
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.3",11010.0445849
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.3",10943.5309892
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.3",10904.9107645
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.3",10856.0275373
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.3",10819.2642301
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.3",10760.0809623
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.3",10717.5075802
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.3",10654.7472358
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.35",11757.7391354
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.35",11755.9487943
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.35",11756.8790732
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.35",11737.6980516
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.35",11732.828545
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.35",11714.2157383
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.35",11702.7508228
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.35",11681.0113713
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.35",11664.8668789
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.35",11642.8600471
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.35",11633.0957638
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.35",11611.0630694
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.35",11586.7426713
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.35",11546.4663922
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.35",11516.6817274
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.35",11498.2118884
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.35",11466.6133484
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.35",11431.9708934
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.35",11408.071054
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.35",11351.2602341
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.35",11332.3901452
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.35",11269.3409548
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.35",11245.4456202
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.35",11188.3625179
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.35",11140.8183552
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.35",11095.4562406
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.35",11061.1275762
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.35",11010.4329795
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.35",10968.5798736
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.35",10907.7701715
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.4",11953.916949
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.4",11947.8978056
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.4",11953.273905
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.4",11934.5028545
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.4",11930.4592534
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.4",11912.4100479
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.4",11903.2335612
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.4",11886.6425633
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.4",11872.6353096
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.4",11848.8559255
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.4",11836.9784535
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.4",11824.2732268
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.4",11792.4914861
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.4",11753.4205005
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.4",11730.9048422
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.4",11710.4069305
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.4",11681.622778
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.4",11649.8624246
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.4",11626.3440196
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.4",11578.0114796
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.4",11550.3636125
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.4",11496.7785954
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.4",11471.5824166
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.4",11414.0289677
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.4",11375.4807931
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.4",11328.728723
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.4",11295.2767842
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.4",11240.7269083
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.4",11203.5053577
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.4",11148.9613529
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.45",12145.2781878
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.45",12141.6656015
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.45",12141.2000741
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.45",12128.2439969
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.45",12124.660739
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.45",12106.1907401
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.45",12098.0434835
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.45",12086.6110926
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.45",12072.2928406
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.45",12051.5521084
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.45",12037.9020359
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.45",12028.5530943
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.45",11993.045242
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.45",11957.7656915
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.45",11944.5220092
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.45",11917.4111516
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.45",11887.0995289
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.45",11861.2506523
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.45",11838.9564863
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.45",11794.5580264
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.45",11766.2301566
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.45",11713.4755417
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.45",11692.7475133
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.45",11642.822276
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.45",11600.9211989
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.45",11557.8762706
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.45",11531.4762765
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.45",11473.7417208
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.45",11431.1874334
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.45",11388.4907803
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.5",12333.2878231
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.5",12333.7615068
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.5",12333.7147506
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.5",12320.5892401
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.5",12315.1348537
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.5",12299.9898898
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.5",12290.854307
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.5",12278.6279246
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.5",12271.0670317
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.5",12248.6640888
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.5",12233.7101592
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.5",12227.4463728
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.5",12195.88078
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.5",12163.1038968
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.5",12151.5235197
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.5",12130.7023282
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.5",12105.365325
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.5",12071.1480322
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.5",12052.2392274
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.5",12008.62297
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.5",11983.67848
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.5",11933.5792896
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.5",11914.1761473
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.5",11866.8831585
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.5",11828.8061003
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.5",11788.3651258
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.5",11763.4167939
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.5",11706.5312323
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.5",11663.7150364
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.5",11624.7794531
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.55",12524.1557929
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.55",12525.6469318
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.55",12529.0716839
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.55",12512.1769367
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.55",12507.7323588
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.55",12499.2343123
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.55",12487.8353644
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.55",12475.5429125
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.55",12468.1334403
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.55",12447.1395221
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.55",12437.8286781
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.55",12433.3497525
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.55",12399.2753416
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.55",12369.0404726
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.55",12357.141476
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.55",12336.3791218
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.55",12321.218572
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.55",12286.4599245
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.55",12266.3136323
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.55",12224.8449025
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.55",12204.5146016
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.55",12157.976377
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.55",12134.7921075
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.55",12094.0250094
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.55",12058.5061278
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.55",12016.3498391
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.55",11995.3583312
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.55",11937.8973755
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.55",11894.9563889
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.55",11865.9677612
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.6",12717.9948525
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.6",12724.8805767
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.6",12725.2904605
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.6",12708.3533584
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.6",12704.7813862
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.6",12697.5274944
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.6",12685.8350593
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.6",12680.9936526
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.6",12670.01137
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.6",12653.6122247
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.6",12645.7242277
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.6",12635.5061703
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.6",12608.4379655
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.6",12579.0945353
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.6",12569.8738345
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.6",12556.7239359
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.6",12535.8765781
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.6",12506.4319267
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.6",12489.6788546
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.6",12451.9735461
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.6",12432.3932624
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.6",12387.5574817
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.6",12362.7544197
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.6",12331.1918743
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.6",12294.0288071
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.6",12255.1800594
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.6",12236.1680021
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.6",12185.8980897
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.6",12145.5922447
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.6",12114.8726675
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.65",12923.8617496
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.65",12929.6852671
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.65",12937.7610008
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.65",12917.7063153
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.65",12912.0614767
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.65",12900.7719449
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.65",12893.8752329
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.65",12897.4343952
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.65",12879.6175415
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.65",12862.0143549
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.65",12860.2920598
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.65",12854.4394105
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.65",12826.5687439
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.65",12802.5396826
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.65",12791.8418891
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.65",12778.6659365
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.65",12759.7898621
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.65",12740.0944298
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.65",12715.8740645
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.65",12691.8352711
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.65",12673.6583601
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.65",12629.3914994
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.65",12602.9616933
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.65",12571.8995677
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.65",12542.7130136
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.65",12506.1270934
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.65",12490.8265095
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.65",12437.7685558
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.65",12402.3321677
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.65",12369.9756279
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.7",13138.2769186
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.7",13149.969876
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.7",13156.1912365
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.7",13137.1908373
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.7",13128.5694745
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.7",13115.7747121
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.7",13108.7583265
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.7",13118.0514024
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.7",13104.5052414
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.7",13092.2136077
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.7",13086.5650556
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.7",13082.4538007
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.7",13058.5790365
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.7",13035.5304932
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.7",13027.6457052
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.7",13020.1399144
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.7",13004.6772018
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.7",12982.0733842
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.7",12959.1162527
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.7",12943.4902361
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.7",12922.76559
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.7",12890.6830828
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.7",12858.7750406
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.7",12833.3516127
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.7",12811.1988001
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.7",12769.928139
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.7",12754.6724898
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.7",12709.1410617
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.7",12672.4582009
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.7",12643.2673917
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.75",13374.7410182
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.75",13385.2041645
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.75",13388.0988901
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.75",13369.1819541
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.75",13363.8289763
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.75",13359.8583381
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.75",13357.764293
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.75",13364.3012251
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.75",13348.2967959
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.75",13337.8258511
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.75",13339.5110495
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.75",13333.7465121
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.75",13308.3986364
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.75",13287.9712673
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.75",13289.5515574
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.75",13277.4263356
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.75",13276.759142
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.75",13252.5444265
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.75",13224.8688088
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.75",13221.3127117
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.75",13202.8769726
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.75",13163.7586193
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.75",13145.5956944
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.75",13123.4168558
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.75",13091.8458433
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.75",13059.676909
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.75",13042.8305432
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.75",13014.4591982
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.75",12972.6189683
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.75",12944.6824264
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.8",13637.3177837
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.8",13652.4159994
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.8",13654.3626543
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.8",13634.3806101
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.8",13632.6472818
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.8",13632.2047116
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.8",13630.5472011
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.8",13637.1098911
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.8",13624.9759356
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.8",13616.1591042
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.8",13617.5089541
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.8",13612.6085491
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.8",13598.6382319
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.8",13578.569001
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.8",13589.1272801
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.8",13567.8227231
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.8",13566.2145265
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.8",13556.4208745
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.8",13520.2180893
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.8",13527.3669622
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.8",13519.665506
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.8",13482.2704189
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.8",13467.265163
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.8",13446.4401124
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.8",13418.4896766
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.8",13383.783715
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.8",13370.6626987
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.8",13349.0988024
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.8",13316.3805514
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.8",13282.0367149
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.85",13940.4927997
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.85",13962.6486118
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.85",13960.3223849
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.85",13952.7132394
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.85",13947.2635095
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.85",13954.3373854
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.85",13957.0164266
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.85",13959.342002
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.85",13946.9228181
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.85",13946.6254516
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.85",13953.2774484
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.85",13951.3351991
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.85",13931.4197186
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.85",13915.9791306
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.85",13935.5354009
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.85",13914.2849107
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.85",13910.2322412
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.85",13913.4788382
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.85",13882.0892922
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.85",13884.4827923
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.85",13891.120277
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.85",13855.4540357
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.85",13842.9560776
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.85",13821.1741547
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.85",13804.0366727
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.85",13772.7390951
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.85",13766.7119494
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.85",13742.6053551
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.85",13716.9096167
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.85",13683.8077118
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.9",14339.817184
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.9",14351.9447435
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.9",14357.9178459
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.9",14348.7068943
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.9",14350.7262276
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.9",14357.887143
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.9",14355.9977594
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.9",14361.1222297
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.9",14361.4354674
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.9",14370.5602642
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.9",14374.2311177
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.9",14375.1398461
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.9",14357.5267165
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.9",14356.7619585
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.9",14383.5311534
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.9",14360.6710512
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.9",14360.2014226
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.9",14356.7256323
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.9",14335.2814716
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.9",14347.9956208
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.9",14355.5681253
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.9",14326.534118
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.9",14326.488919
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.9",14304.7835558
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.9",14290.8286444
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.9",14266.0171773
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.9",14263.7517345
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.9",14253.3156193
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.9",14231.2671992
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.9",14198.7947139
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.95",14935.9775049
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.95",14940.4638689
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.95",14955.900066
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.95",14965.6810322
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.95",14960.131296
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.95",14973.9680881
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.95",14977.3675286
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.95",14977.2718296
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.95",14977.4914375
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.95",15001.5400199
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.95",15001.6066078
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.95",15031.837104
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.95",14997.353157
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.95",14998.2677192
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.95",15065.7353452
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.95",15016.0122222
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.95",15029.4080701
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.95",15024.4216965
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.95",15027.9119974
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.95",15051.6066879
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.95",15072.1683809
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.95",15032.527386
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.95",15039.6530447
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.95",15036.5233805
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.95",15011.7854594
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.95",15015.2983964
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.95",15020.840276
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.95",15016.0131099
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.95",15013.9026252
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.95",14980.5937564
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.975",15452.9813678
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.975",15491.6227105
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.975",15512.7536316
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.975",15492.0175636
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.975",15507.5851032
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.975",15526.5609653
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.975",15533.679027
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.975",15517.7651196
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.975",15536.232169
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.975",15542.552665
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.975",15567.9030711
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.975",15600.7871083
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.975",15570.4267191
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.975",15581.6769386
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.975",15650.6849995
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.975",15610.1737582
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.975",15622.3896519
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.975",15601.352904
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.975",15653.4877268
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.975",15656.4069456
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.975",15671.6913647
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.975",15666.7594999
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.975",15658.4265981
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.975",15678.3615472
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.975",15671.908765
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.975",15668.5755269
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.975",15679.3250859
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.975",15676.2925444
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.975",15704.4071407
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.975",15665.1327905
+2020-12-07,"1 day ahead inc case",2020-12-08,"GM","Germany","quantile","0.99",16083.0552866
+2020-12-07,"2 day ahead inc case",2020-12-09,"GM","Germany","quantile","0.99",16131.5654318
+2020-12-07,"3 day ahead inc case",2020-12-10,"GM","Germany","quantile","0.99",16157.329945
+2020-12-07,"4 day ahead inc case",2020-12-11,"GM","Germany","quantile","0.99",16112.9380884
+2020-12-07,"5 day ahead inc case",2020-12-12,"GM","Germany","quantile","0.99",16140.9644368
+2020-12-07,"6 day ahead inc case",2020-12-13,"GM","Germany","quantile","0.99",16188.5486421
+2020-12-07,"7 day ahead inc case",2020-12-14,"GM","Germany","quantile","0.99",16174.0508293
+2020-12-07,"8 day ahead inc case",2020-12-15,"GM","Germany","quantile","0.99",16152.568374
+2020-12-07,"9 day ahead inc case",2020-12-16,"GM","Germany","quantile","0.99",16196.1095178
+2020-12-07,"10 day ahead inc case",2020-12-17,"GM","Germany","quantile","0.99",16211.4812732
+2020-12-07,"11 day ahead inc case",2020-12-18,"GM","Germany","quantile","0.99",16209.9551526
+2020-12-07,"12 day ahead inc case",2020-12-19,"GM","Germany","quantile","0.99",16301.5929102
+2020-12-07,"13 day ahead inc case",2020-12-20,"GM","Germany","quantile","0.99",16269.9378211
+2020-12-07,"14 day ahead inc case",2020-12-21,"GM","Germany","quantile","0.99",16280.4600867
+2020-12-07,"15 day ahead inc case",2020-12-22,"GM","Germany","quantile","0.99",16334.5189438
+2020-12-07,"16 day ahead inc case",2020-12-23,"GM","Germany","quantile","0.99",16353.0171705
+2020-12-07,"17 day ahead inc case",2020-12-24,"GM","Germany","quantile","0.99",16331.5162239
+2020-12-07,"18 day ahead inc case",2020-12-25,"GM","Germany","quantile","0.99",16310.6154668
+2020-12-07,"19 day ahead inc case",2020-12-26,"GM","Germany","quantile","0.99",16412.950015
+2020-12-07,"20 day ahead inc case",2020-12-27,"GM","Germany","quantile","0.99",16369.95458
+2020-12-07,"21 day ahead inc case",2020-12-28,"GM","Germany","quantile","0.99",16411.5943121
+2020-12-07,"22 day ahead inc case",2020-12-29,"GM","Germany","quantile","0.99",16404.3120649
+2020-12-07,"23 day ahead inc case",2020-12-30,"GM","Germany","quantile","0.99",16418.775455
+2020-12-07,"24 day ahead inc case",2020-12-31,"GM","Germany","quantile","0.99",16417.7144667
+2020-12-07,"25 day ahead inc case",2021-01-01,"GM","Germany","quantile","0.99",16436.9849852
+2020-12-07,"26 day ahead inc case",2021-01-02,"GM","Germany","quantile","0.99",16432.3936771
+2020-12-07,"27 day ahead inc case",2021-01-03,"GM","Germany","quantile","0.99",16474.3033458
+2020-12-07,"28 day ahead inc case",2021-01-04,"GM","Germany","quantile","0.99",16405.3889879
+2020-12-07,"29 day ahead inc case",2021-01-05,"GM","Germany","quantile","0.99",16483.3352408
+2020-12-07,"30 day ahead inc case",2021-01-06,"GM","Germany","quantile","0.99",16492.0704822
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","point",NA,1195988.2878231
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","point",NA,1208322.0493299
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","point",NA,1220655.7640805
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","point",NA,1232976.3533206
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","point",NA,1245291.4881743
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","point",NA,1257591.4780642
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","point",NA,1269882.3323712
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","point",NA,1282160.9602957
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","point",NA,1294432.0273274
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","point",NA,1306680.6914162
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","point",NA,1318914.4015754
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","point",NA,1331141.8479482
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","point",NA,1343337.7287282
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","point",NA,1355500.832625
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","point",NA,1367652.3561447
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","point",NA,1379783.0584729
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","point",NA,1391888.4237979
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","point",NA,1403959.5718302
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","point",NA,1416011.8110576
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","point",NA,1428020.4340275
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","point",NA,1440004.1125076
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","point",NA,1451937.6917971
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","point",NA,1463851.8679444
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","point",NA,1475718.7511028
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","point",NA,1487547.5572031
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","point",NA,1499335.9223289
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","point",NA,1511099.3391229
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","point",NA,1522805.8703552
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","point",NA,1534469.5853916
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","point",NA,1546094.3648446
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.01",1192738.7914789
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.01",1201800.6774587
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.01",1210841.6240675
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.01",1219868.0998808
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.01",1228847.3453985
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.01",1237841.2122668
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.01",1246775.0371963
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.01",1255689.0051302
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.01",1264619.3030805
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.01",1273459.1451512
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.01",1282300.1505461
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.01",1291078.1477429
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.01",1299825.0580803
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.01",1308550.5252992
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.01",1317200.6720748
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.01",1325822.7501673
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.01",1334349.3389543
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.01",1342854.787045
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.01",1351301.2105085
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.01",1359687.8632196
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.01",1368007.3063322
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.01",1376273.2362353
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.01",1384463.1218164
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.01",1392618.0248878
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.01",1400736.9213943
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.01",1408770.3341588
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.01",1416755.3612373
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.01",1424653.8015639
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.01",1432514.5723926
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.01",1440321.9545399
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.025",1193224.1649781
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.025",1202768.9509325
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.025",1212297.9544643
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.025",1221806.6987519
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.025",1231293.3185223
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.025",1240763.9470419
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.025",1250213.4604165
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.025",1259635.69798
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.025",1269038.527498
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.025",1278383.9468341
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.025",1287694.3874705
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.025",1296973.2377149
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.025",1306217.2995064
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.025",1315421.946435
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.025",1324590.4541566
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.025",1333706.3218125
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.025",1342738.3948916
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.025",1351753.5443833
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.025",1360707.9497425
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.025",1369608.032334
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.025",1378458.25808
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.025",1387247.6119984
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.025",1395975.8607536
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.025",1404660.3193185
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.025",1413282.2354997
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.025",1421830.644515
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.025",1430342.2258288
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.025",1438758.0304192
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.025",1447144.5306832
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.025",1455463.3231719
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.05",1193641.0262872
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.05",1203604.7295225
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.05",1213560.9750914
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.05",1223484.8609444
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.05",1233408.7509084
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.05",1243310.1065326
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.05",1253192.8571317
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.05",1263055.7748614
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.05",1272898.5874148
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.05",1282688.5199888
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.05",1292448.5755258
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.05",1302170.353305
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.05",1311862.0514573
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.05",1321515.309214
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.05",1331124.8379606
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.05",1340676.182275
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.05",1350173.4852107
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.05",1359645.1286642
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.05",1369073.8063068
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.05",1378423.5118056
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.05",1387736.808809
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.05",1396992.1864829
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.05",1406189.047072
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.05",1415337.5321332
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.05",1424419.5724328
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.05",1433449.1547645
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.05",1442439.2410743
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.05",1451343.1703814
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.05",1460197.8784809
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.05",1468996.3391574
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.1",1194137.0741294
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.1",1204604.0137996
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.1",1215068.1003312
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.1",1225505.9323254
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.1",1235935.2559265
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.1",1246340.7532922
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.1",1256734.1532584
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.1",1267105.2928781
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.1",1277449.0769184
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.1",1287761.5186651
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.1",1298047.3168673
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.1",1308285.3504916
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.1",1318499.9577384
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.1",1328676.2033697
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.1",1338818.1149939
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.1",1348918.7493553
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.1",1358969.1578617
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.1",1368985.7128599
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.1",1378963.3765071
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.1",1388871.5500261
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.1",1398747.9341094
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.1",1408554.8933575
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.1",1418319.5823288
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.1",1428029.1395658
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.1",1437682.6154213
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.1",1447266.0992158
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.1",1456820.2665226
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.1",1466307.3017132
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.1",1475737.6742166
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.1",1485101.6037338
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.15",1194476.2637945
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.15",1205285.3327174
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.15",1216095.000988
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.15",1226882.6989981
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.15",1237662.4442786
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.15",1248417.0459587
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.15",1259156.7434091
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.15",1269877.9692372
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.15",1280578.0775234
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.15",1291239.3780904
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.15",1301878.2812245
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.15",1312491.6607523
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.15",1323067.46669
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.15",1333614.6218904
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.15",1344117.5553436
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.15",1354586.1311519
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.15",1365006.6109896
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.15",1375396.6739706
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.15",1385753.0769387
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.15",1396048.167038
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.15",1406317.8849549
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.15",1416508.6574599
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.15",1426668.8620809
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.15",1436774.2409331
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.15",1446816.5081369
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.15",1456809.8096116
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.15",1466759.4680979
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.15",1476644.2036021
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.15",1486482.6150312
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.15",1496253.0109562
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.2",1194749.2659133
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.2",1205840.2189994
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.2",1216934.2526774
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.2",1228002.7737959
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.2",1239058.8138535
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.2",1250103.1412838
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.2",1261128.4304415
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.2",1272129.0062809
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.2",1283116.5566906
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.2",1294061.633794
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.2",1304992.410534
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.2",1315897.4533802
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.2",1326764.0879958
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.2",1337605.6648216
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.2",1348404.1623808
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.2",1359178.5563286
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.2",1369915.3794907
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.2",1380607.8871669
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.2",1391271.0405764
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.2",1401871.7064484
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.2",1412451.8247799
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.2",1422955.6873753
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.2",1433428.8222775
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.2",1443845.5998284
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.2",1454208.4273235
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.2",1464517.8690394
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.2",1474786.6398684
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.2",1485003.4164294
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.2",1495174.617766
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.2",1505278.1512973
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.25",1194990.0874684
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.25",1206322.9013672
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.25",1217656.7958668
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.25",1228966.8152768
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.25",1240268.1055365
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.25",1251556.1803097
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.25",1262824.4938141
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.25",1274075.0438654
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.25",1285308.8555136
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.25",1296507.1459414
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.25",1307692.9002975
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.25",1318851.1468319
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.25",1329979.9628307
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.25",1341076.2939748
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.25",1352142.4066917
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.25",1363177.1736451
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.25",1374177.8975946
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.25",1385136.1991383
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.25",1396065.7532875
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.25",1406934.0184936
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.25",1417783.6149822
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.25",1428568.2956532
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.25",1439326.2236669
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.25",1450018.5957172
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.25",1460669.6559413
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.25",1471264.8174671
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.25",1481825.2772782
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.25",1492330.7244305
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.25",1502786.030557
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.25",1513179.1257669
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.3",1195211.5563305
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.3",1206760.7493269
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.3",1218307.1756625
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.3",1229835.3402552
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.3",1241359.0878084
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.3",1252870.7397145
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.3",1264361.1829931
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.3",1275833.9375539
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.3",1287294.4863384
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.3",1298727.0368101
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.3",1310142.1284429
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.3",1321534.9224231
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.3",1332896.3542759
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.3",1344225.3450156
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.3",1355527.8876978
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.3",1366801.9190104
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.3",1378045.5535922
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.3",1389248.942733
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.3",1400425.6106961
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.3",1411542.6395684
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.3",1422641.3012312
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.3",1433675.6655163
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.3",1444685.7101011
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.3",1455629.2410904
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.3",1466534.1518548
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.3",1477390.1793921
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.3",1488209.4436223
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.3",1498969.5245846
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.3",1509687.0321648
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.3",1520341.7794006
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.35",1195412.7391354
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.35",1207168.6879297
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.35",1218925.5670028
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.35",1230663.2650545
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.35",1242396.0935995
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.35",1254110.3093378
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.35",1265813.0601606
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.35",1277494.0715319
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.35",1289158.9384108
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.35",1300801.7984579
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.35",1312434.8942217
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.35",1324045.9572911
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.35",1335632.6999624
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.35",1347179.1663546
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.35",1358695.848082
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.35",1370194.0599703
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.35",1381660.6733188
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.35",1393092.6442121
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.35",1404500.7152662
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.35",1415851.9755003
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.35",1427184.3656455
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.35",1438453.7066003
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.35",1449699.1522205
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.35",1460887.5147385
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.35",1472028.3330936
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.35",1483123.7893342
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.35",1494184.9169104
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.35",1505195.3498898
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.35",1516163.9297634
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.35",1527071.6999349
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.4",1195608.916949
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.4",1207556.8147546
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.4",1219510.0886596
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.4",1231444.591514
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.4",1243375.0507674
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.4",1255287.4608153
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.4",1267190.6943764
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.4",1279077.3369398
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.4",1290949.9722493
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.4",1302798.8281748
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.4",1314635.8066283
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.4",1326460.0798551
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.4",1338252.5713412
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.4",1350005.9918417
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.4",1361736.8966839
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.4",1373447.3036144
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.4",1385128.9263924
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.4",1396778.788817
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.4",1408405.1328366
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.4",1419983.1443161
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.4",1431533.5079286
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.4",1443030.286524
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.4",1454501.8689406
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.4",1465915.8979083
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.4",1477291.3787014
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.4",1488620.1074244
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.4",1499915.3842087
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.4",1511156.111117
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.4",1522359.6164747
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.4",1533508.5778276
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.45",1195800.2781878
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.45",1207941.9437893
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.45",1220083.1438634
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.45",1232211.3878603
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.45",1244336.0485993
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.45",1256442.2393394
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.45",1268540.2828229
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.45",1280626.8939156
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.45",1292699.1867561
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.45",1304750.7388645
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.45",1316788.6409004
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.45",1328817.1939947
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.45",1340810.2392367
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.45",1352768.0049282
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.45",1364712.5269374
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.45",1376629.9380891
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.45",1388517.037618
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.45",1400378.2882703
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.45",1412217.2447566
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.45",1424011.8027829
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.45",1435778.0329396
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.45",1447491.5084812
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.45",1459184.2559945
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.45",1470827.0782704
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.45",1482427.9994693
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.45",1493985.87574
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.45",1505517.3520165
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.45",1516991.0937373
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.45",1528422.2811707
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.45",1539810.7719511
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.5",1195988.2878231
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.5",1208322.0493299
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.5",1220655.7640805
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.5",1232976.3533206
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.5",1245291.4881743
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.5",1257591.4780642
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.5",1269882.3323712
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.5",1282160.9602957
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.5",1294432.0273274
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.5",1306680.6914162
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.5",1318914.4015754
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.5",1331141.8479482
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.5",1343337.7287282
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.5",1355500.832625
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.5",1367652.3561447
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.5",1379783.0584729
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.5",1391888.4237979
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.5",1403959.5718302
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.5",1416011.8110576
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.5",1428020.4340275
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.5",1440004.1125076
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.5",1451937.6917971
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.5",1463851.8679444
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.5",1475718.7511028
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.5",1487547.5572031
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.5",1499335.9223289
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.5",1511099.3391229
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.5",1522805.8703552
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.5",1534469.5853916
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.5",1546094.3648446
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.55",1196179.1557929
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.55",1208704.8027248
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.55",1221233.8744086
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.55",1233746.0513453
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.55",1246253.7837041
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.55",1258753.0180164
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.55",1271240.8533808
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.55",1283716.3962934
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.55",1296184.5297336
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.55",1308631.6692557
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.55",1321069.4979338
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.55",1333502.8476863
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.55",1345902.1230279
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.55",1358271.1635004
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.55",1370628.3049765
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.55",1382964.6840983
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.55",1395285.9026703
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.55",1407572.3625948
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.55",1419838.6762271
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.55",1432063.5211296
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.55",1444268.0357312
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.55",1456426.0121081
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.55",1468560.8042157
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.55",1480654.8292251
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.55",1492713.3353529
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.55",1504729.685192
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.55",1516725.0435232
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.55",1528662.9408988
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.55",1540557.8972876
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.55",1552423.8650489
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.6",1196372.9948525
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.6",1209097.8754292
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.6",1221823.1658897
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.6",1234531.5192481
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.6",1247236.3006343
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.6",1259933.8281287
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.6",1272619.663188
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.6",1285300.6568407
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.6",1297970.6682107
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.6",1310624.2804354
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.6",1323270.0046631
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.6",1335905.5108334
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.6",1348513.9487989
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.6",1361093.0433342
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.6",1373662.9171687
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.6",1386219.6411046
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.6",1398755.5176827
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.6",1411261.9496095
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.6",1423751.628464
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.6",1436203.6020102
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.6",1448635.9952726
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.6",1461023.5527542
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.6",1473386.3071739
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.6",1485717.4990482
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.6",1498011.5278553
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.6",1510266.7079147
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.6",1522502.8759168
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.6",1534688.7740065
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.6",1546834.3662511
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.6",1558949.2389186
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.65",1196578.8617496
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.65",1209508.5470167
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.65",1222446.3080175
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.65",1235364.0143328
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.65",1248276.0758095
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.65",1261176.8477544
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.65",1274070.7229873
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.65",1286968.1573826
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.65",1299847.7749241
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.65",1312709.7892789
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.65",1325570.0813387
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.65",1338424.5207492
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.65",1351251.0894931
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.65",1364053.6291758
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.65",1376845.4710648
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.65",1389624.1370014
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.65",1402383.9268634
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.65",1415124.0212932
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.65",1427839.8953577
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.65",1440531.7306288
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.65",1453205.3889889
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.65",1465834.7804884
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.65",1478437.7421816
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.65",1491009.6417493
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.65",1503552.354763
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.65",1516058.4818563
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.65",1528549.3083658
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.65",1540987.0769216
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.65",1553389.4090894
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.65",1565759.3847173
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.7",1196793.2769186
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.7",1209943.2467945
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.7",1223099.438031
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.7",1236236.6288684
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.7",1249365.1983429
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.7",1262480.973055
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.7",1275589.7313816
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.7",1288707.782784
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.7",1301812.2880254
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.7",1314904.5016331
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.7",1327991.0666887
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.7",1341073.5204894
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.7",1354132.0995258
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.7",1367167.6300191
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.7",1380195.2757243
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.7",1393215.4156386
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.7",1406220.0928404
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.7",1419202.1662246
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.7",1432161.2824774
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.7",1445104.7727134
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.7",1458027.5383034
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.7",1470918.2213862
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.7",1483776.9964268
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.7",1496610.3480394
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.7",1509421.5468396
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.7",1522191.4749785
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.7",1534946.1474683
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.7",1547655.2885301
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.7",1560327.746731
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.7",1572971.0141227
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.75",1197029.7410182
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.75",1210414.9451828
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.75",1223803.0440728
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.75",1237172.226027
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.75",1250536.0550033
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.75",1263895.9133414
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.75",1277253.6776344
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.75",1290617.9788595
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.75",1303966.2756553
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.75",1317304.1015064
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.75",1330643.6125559
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.75",1343977.359068
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.75",1357285.7577044
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.75",1370573.7289717
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.75",1383863.280529
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.75",1397140.7068646
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.75",1410417.4660066
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.75",1423670.0104331
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.75",1436894.8792419
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.75",1450116.1919536
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.75",1463319.0689262
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.75",1476482.8275455
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.75",1489628.4232398
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.75",1502751.8400957
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.75",1515843.685939
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.75",1528903.362848
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.75",1541946.1933912
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.75",1554960.6525894
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.75",1567933.2715577
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.75",1580877.9539841
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.8",1197292.3177837
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.8",1210944.7337831
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.8",1224599.0964374
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.8",1238233.4770475
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.8",1251866.1243293
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.8",1265498.3290409
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.8",1279128.8762421
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.8",1292765.9861331
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.8",1306390.9620687
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.8",1320007.1211729
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.8",1333624.630127
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.8",1347237.2386761
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.8",1360835.876908
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.8",1374414.445909
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.8",1388003.5731891
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.8",1401571.3959122
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.8",1415137.6104387
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.8",1428694.0313132
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.8",1442214.2494025
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.8",1455741.6163647
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.8",1469261.2818707
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.8",1482743.5522896
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.8",1496210.8174526
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.8",1509657.257565
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.8",1523075.7472416
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.8",1536459.5309566
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.8",1549830.1936553
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.8",1563179.2924577
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.8",1576495.6730092
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.8",1589777.7097241
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.85",1197595.4927997
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.85",1211558.1414115
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.85",1225518.4637963
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.85",1239471.1770357
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.85",1253418.4405452
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.85",1267372.7779306
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.85",1281329.7943572
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.85",1295289.1363592
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.85",1309236.0591773
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.85",1323182.6846289
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.85",1337135.9620772
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.85",1351087.2972763
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.85",1365018.7169949
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.85",1378934.6961255
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.85",1392870.2315263
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.85",1406784.516437
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.85",1420694.7486783
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.85",1434608.2275164
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.85",1448490.3168087
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.85",1462374.799601
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.85",1476265.919878
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.85",1490121.3739137
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.85",1503964.3299912
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.85",1517785.5041459
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.85",1531589.5408186
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.85",1545362.2799138
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.85",1559128.9918632
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.85",1572871.5972183
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.85",1586588.506835
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.85",1600272.3145467
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.9",1197994.817184
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.9",1212346.7619276
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.9",1226704.6797735
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.9",1241053.3866678
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.9",1255404.1128954
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.9",1269762.0000384
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.9",1284117.9977978
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.9",1298479.1200275
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.9",1312840.5554949
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.9",1327211.1157591
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.9",1341585.3468768
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.9",1355960.486723
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.9",1370318.0134395
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.9",1384674.7753979
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.9",1399058.3065513
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.9",1413418.9776025
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.9",1427779.1790251
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.9",1442135.9046573
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.9",1456471.186129
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.9",1470819.1817498
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.9",1485174.7498751
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.9",1499501.2839931
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.9",1513827.7729121
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.9",1528132.5564679
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.9",1542423.3851122
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.9",1556689.4022896
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.9",1570953.154024
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.9",1585206.4696433
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.9",1599437.7368425
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.9",1613636.5315564
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.95",1198590.9775049
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.95",1213531.4413738
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.95",1228487.3414397
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.95",1243453.022472
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.95",1258413.153768
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.95",1273387.1218561
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.95",1288364.4893847
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.95",1303341.7612143
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.95",1318319.2526519
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.95",1333320.7926718
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.95",1348322.3992796
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.95",1363354.2363836
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.95",1378351.5895406
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.95",1393349.8572597
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.95",1408415.5926049
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.95",1423431.6048271
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.95",1438461.0128972
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.95",1453485.4345937
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.95",1468513.3465911
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.95",1483564.953279
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.95",1498637.1216599
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.95",1513669.649046
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.95",1528709.3020906
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.95",1543745.8254712
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.95",1558757.6109306
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.95",1573772.909327
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.95",1588793.749603
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.95",1603809.7627128
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.95",1618823.665338
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.95",1633804.2590944
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.975",1199107.9813678
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.975",1214599.6040782
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.975",1230112.3577098
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.975",1245604.3752735
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.975",1261111.9603767
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.975",1276638.521342
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.975",1292172.2003689
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.975",1307689.9654886
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.975",1323226.1976576
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.975",1338768.7503225
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.975",1354336.6533936
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.975",1369937.4405019
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.975",1385507.867221
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.975",1401089.5441597
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.975",1416740.2291592
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.975",1432350.4029173
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.975",1447972.7925692
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.975",1463574.1454732
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.975",1479227.6332
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.975",1494884.0401456
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.975",1510555.7315104
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.975",1526222.4910102
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.975",1541880.9176083
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.975",1557559.2791555
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.975",1573231.1879205
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.975",1588899.7634474
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.975",1604579.0885333
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.975",1620255.3810776
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.975",1635959.7882183
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.975",1651624.9210089
+2020-12-07,"1 day ahead cum case",2020-12-08,"GM","Germany","quantile","0.99",1199738.0552866
+2020-12-07,"2 day ahead cum case",2020-12-09,"GM","Germany","quantile","0.99",1215869.6207184
+2020-12-07,"3 day ahead cum case",2020-12-10,"GM","Germany","quantile","0.99",1232026.9506634
+2020-12-07,"4 day ahead cum case",2020-12-11,"GM","Germany","quantile","0.99",1248139.8887517
+2020-12-07,"5 day ahead cum case",2020-12-12,"GM","Germany","quantile","0.99",1264280.8531885
+2020-12-07,"6 day ahead cum case",2020-12-13,"GM","Germany","quantile","0.99",1280469.4018306
+2020-12-07,"7 day ahead cum case",2020-12-14,"GM","Germany","quantile","0.99",1296643.4526599
+2020-12-07,"8 day ahead cum case",2020-12-15,"GM","Germany","quantile","0.99",1312796.0210339
+2020-12-07,"9 day ahead cum case",2020-12-16,"GM","Germany","quantile","0.99",1328992.1305518
+2020-12-07,"10 day ahead cum case",2020-12-17,"GM","Germany","quantile","0.99",1345203.6118249
+2020-12-07,"11 day ahead cum case",2020-12-18,"GM","Germany","quantile","0.99",1361413.5669775
+2020-12-07,"12 day ahead cum case",2020-12-19,"GM","Germany","quantile","0.99",1377715.1598876
+2020-12-07,"13 day ahead cum case",2020-12-20,"GM","Germany","quantile","0.99",1393985.0977088
+2020-12-07,"14 day ahead cum case",2020-12-21,"GM","Germany","quantile","0.99",1410265.5577955
+2020-12-07,"15 day ahead cum case",2020-12-22,"GM","Germany","quantile","0.99",1426600.0767393
+2020-12-07,"16 day ahead cum case",2020-12-23,"GM","Germany","quantile","0.99",1442953.0939098
+2020-12-07,"17 day ahead cum case",2020-12-24,"GM","Germany","quantile","0.99",1459284.6101336
+2020-12-07,"18 day ahead cum case",2020-12-25,"GM","Germany","quantile","0.99",1475595.2256004
+2020-12-07,"19 day ahead cum case",2020-12-26,"GM","Germany","quantile","0.99",1492008.1756154
+2020-12-07,"20 day ahead cum case",2020-12-27,"GM","Germany","quantile","0.99",1508378.1301954
+2020-12-07,"21 day ahead cum case",2020-12-28,"GM","Germany","quantile","0.99",1524789.7245076
+2020-12-07,"22 day ahead cum case",2020-12-29,"GM","Germany","quantile","0.99",1541194.0365725
+2020-12-07,"23 day ahead cum case",2020-12-30,"GM","Germany","quantile","0.99",1557612.8120275
+2020-12-07,"24 day ahead cum case",2020-12-31,"GM","Germany","quantile","0.99",1574030.5264942
+2020-12-07,"25 day ahead cum case",2021-01-01,"GM","Germany","quantile","0.99",1590467.5114794
+2020-12-07,"26 day ahead cum case",2021-01-02,"GM","Germany","quantile","0.99",1606899.9051565
+2020-12-07,"27 day ahead cum case",2021-01-03,"GM","Germany","quantile","0.99",1623374.2085023
+2020-12-07,"28 day ahead cum case",2021-01-04,"GM","Germany","quantile","0.99",1639779.5974902
+2020-12-07,"29 day ahead cum case",2021-01-05,"GM","Germany","quantile","0.99",1656262.932731
+2020-12-07,"30 day ahead cum case",2021-01-06,"GM","Germany","quantile","0.99",1672755.0032132
+2020-12-07,"-1 wk ahead inc case",2020-11-28,"GM","Germany","observed",NA,125561
+2020-12-07,"0 wk ahead inc case",2020-12-05,"GM","Germany","observed",NA,125467
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.01",111298.2455132
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.01",109124.8201803
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.01",106246.7153526
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.01",102682.806024
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.025",113351.8510239
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.025",111358.6013713
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.025",108470.5536901
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.025",105064.0422018
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.05",115127.0794573
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.05",113245.8149136
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.05",110506.6078865
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.05",107129.2195742
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.1",117228.8433615
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.1",115506.0371805
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.1",112868.9196981
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.1",109594.3963714
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.15",118659.8696868
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.15",117025.0656379
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.15",114497.699422
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.15",111287.7823063
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.2",119785.1310197
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.2",118226.650818
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.2",115775.6203721
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.2",112659.3758758
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.25",120778.3428803
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.25",119248.7938977
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.25",116866.8041251
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.25",113859.3887797
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.3",121666.9541182
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.3",120188.465315
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.3",117893.36774
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.3",114929.8807664
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.35",122510.2887026
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.35",121067.1438729
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.35",118830.0763466
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.35",115932.4875134
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.4",123296.660787
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.4",121897.485399
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.4",119746.7901431
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.4",116877.9092436
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.45",124079.140532
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.45",122703.3009605
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.45",120595.5047488
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.45",117793.4475202
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","point",NA,124829.0608478
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","point",NA,123470.8816111
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","point",NA,121426.7919368
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","point",NA,118697.1036638
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.55",125589.8696923
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.55",124271.1010759
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.55",122295.1140573
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.55",119599.1058728
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.6",126362.1441782
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.6",125072.8004763
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.6",123168.3456956
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.6",120534.1242341
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.65",127177.9011546
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.65",125927.4995536
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.65",124060.8652549
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.65",121524.0293184
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.7",128026.1041024
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.7",126831.2048606
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.7",125018.3293166
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.7",122526.2719364
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.75",128943.2542355
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.75",127825.3103806
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.75",126046.0174944
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.75",123620.7422517
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.8",129981.6211364
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.8",128907.7384
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.8",127222.6066658
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.8",124850.994504
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.85",131177.7076032
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.85",130210.0562819
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.85",128595.6106406
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.85",126321.8682724
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.9",132715.0463034
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.9",131795.5802025
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.9",130300.5470171
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.9",128159.4445691
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.95",134946.3696213
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.95",134212.2471706
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.95",132927.6971489
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.95",130856.4325481
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.975",136951.887287
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.975",136314.2500132
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.975",135118.991639
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.975",133320.0673661
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.99",139135.5586463
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.99",138857.6010087
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.99",137794.4169333
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.99",136227.6249546
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM","Germany","quantile","0.5",124829.0608478
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM","Germany","quantile","0.5",123470.8816111
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM","Germany","quantile","0.5",121426.7919368
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM","Germany","quantile","0.5",118697.1036638
+2020-12-07,"-1 wk ahead cum case",2020-11-28,"GM","Germany","observed",NA,1028089
+2020-12-07,"0 wk ahead cum case",2020-12-05,"GM","Germany","observed",NA,1153556
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","point",NA,1245291.4881743
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","point",NA,1331141.8479482
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","point",NA,1416011.8110576
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","point",NA,1499335.9223289
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.01",1228847.3453985
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.01",1291078.1477429
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.01",1351301.2105085
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.01",1408770.3341588
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.025",1231293.3185223
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.025",1296973.2377149
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.025",1360707.9497425
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.025",1421830.644515
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.05",1233408.7509084
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.05",1302170.353305
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.05",1369073.8063068
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.05",1433449.1547645
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.1",1235935.2559265
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.1",1308285.3504916
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.1",1378963.3765071
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.1",1447266.0992158
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.15",1237662.4442786
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.15",1312491.6607523
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.15",1385753.0769387
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.15",1456809.8096116
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.2",1239058.8138535
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.2",1315897.4533802
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.2",1391271.0405764
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.2",1464517.8690394
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.25",1240268.1055365
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.25",1318851.1468319
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.25",1396065.7532875
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.25",1471264.8174671
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.3",1241359.0878084
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.3",1321534.9224231
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.3",1400425.6106961
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.3",1477390.1793921
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.35",1242396.0935995
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.35",1324045.9572911
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.35",1404500.7152662
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.35",1483123.7893342
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.4",1243375.0507674
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.4",1326460.0798551
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.4",1408405.1328366
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.4",1488620.1074244
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.45",1244336.0485993
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.45",1328817.1939947
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.45",1412217.2447566
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.45",1493985.87574
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.5",1245291.4881743
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.5",1331141.8479482
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.5",1416011.8110576
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.5",1499335.9223289
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.55",1246253.7837041
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.55",1333502.8476863
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.55",1419838.6762271
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.55",1504729.685192
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.6",1247236.3006343
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.6",1335905.5108334
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.6",1423751.628464
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.6",1510266.7079147
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.65",1248276.0758095
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.65",1338424.5207492
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.65",1427839.8953577
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.65",1516058.4818563
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.7",1249365.1983429
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.7",1341073.5204894
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.7",1432161.2824774
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.7",1522191.4749785
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.75",1250536.0550033
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.75",1343977.359068
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.75",1436894.8792419
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.75",1528903.362848
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.8",1251866.1243293
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.8",1347237.2386761
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.8",1442214.2494025
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.8",1536459.5309566
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.85",1253418.4405452
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.85",1351087.2972763
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.85",1448490.3168087
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.85",1545362.2799138
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.9",1255404.1128954
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.9",1355960.486723
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.9",1456471.186129
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.9",1556689.4022896
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.95",1258413.153768
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.95",1363354.2363836
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.95",1468513.3465911
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.95",1573772.909327
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.975",1261111.9603767
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.975",1369937.4405019
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.975",1479227.6332
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.975",1588899.7634474
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM","Germany","quantile","0.99",1264280.8531885
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM","Germany","quantile","0.99",1377715.1598876
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM","Germany","quantile","0.99",1492008.1756154
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM","Germany","quantile","0.99",1606899.9051565
+2020-12-07,"-1 wk ahead inc case",2020-11-28,"GM13","Free State of Saxony","observed",NA,11075
+2020-12-07,"0 wk ahead inc case",2020-12-05,"GM13","Free State of Saxony","observed",NA,13419
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.01",15402.4087843
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.01",18782.1702272
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.01",22031.5894972
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.01",24681.7927116
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.025",15625.5128087
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.025",19041.6382836
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.025",22327.1263025
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.025",25026.1313935
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.05",15822.6712874
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.05",19273.9976852
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.05",22586.5440275
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.05",25316.1515561
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.1",16044.1707859
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.1",19540.1374899
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.1",22892.9430098
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.1",25660.2973909
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.15",16194.3176494
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.15",19715.8717876
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.15",23100.5967433
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.15",25896.2352837
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.2",16311.7173127
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.2",19859.5525503
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.2",23269.7200908
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.2",26089.0644353
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.25",16415.4414889
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.25",19982.1910803
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.25",23414.5037977
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.25",26252.3226348
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.3",16507.9584045
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.3",20094.1193535
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.3",23544.9352432
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.3",26396.6494422
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.35",16593.1158366
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.35",20194.9716848
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.35",23664.6414917
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.35",26535.3867446
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.4",16674.2876288
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.4",20294.9336257
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.4",23779.5653227
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.4",26663.1975229
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.45",16753.0480364
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.45",20389.9995416
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.45",23894.237196
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.45",26789.8787581
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","point",NA,16832.2536184
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","point",NA,20482.7248623
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","point",NA,24005.0660146
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","point",NA,26914.0574756
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.55",16911.5065855
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.55",20574.4723582
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.55",24116.8140138
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.55",27043.6407809
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.6",16991.8553511
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.6",20668.8638353
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.6",24230.2393417
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.6",27170.6603464
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.65",17076.0153553
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.65",20770.8234265
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.65",24346.7245698
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.65",27301.2644392
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.7",17165.5333061
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.7",20876.4336367
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.7",24469.3451653
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.7",27444.7725996
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.75",17259.8318015
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.75",20987.6317988
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.75",24602.6112211
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.75",27600.6360788
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.8",17366.0593885
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.8",21117.9961745
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.8",24751.7294403
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.8",27774.5389104
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.85",17488.2672674
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.85",21266.2604613
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.85",24925.9450513
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.85",27974.6349168
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.9",17648.7623084
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.9",21456.2224358
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.9",25150.2271703
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.9",28230.8597376
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.95",17884.7619671
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.95",21740.6812975
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.95",25489.3548373
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.95",28612.989759
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.975",18084.9437458
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.975",21985.9307635
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.975",25777.5159496
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.975",28953.0727897
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.99",18326.0456362
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.99",22273.4323379
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.99",26130.0485724
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.99",29344.138197
+2020-12-07,"1 wk ahead inc case",2020-12-12,"GM13","Free State of Saxony","quantile","0.5",16832.2536184
+2020-12-07,"2 wk ahead inc case",2020-12-19,"GM13","Free State of Saxony","quantile","0.5",20482.7248623
+2020-12-07,"3 wk ahead inc case",2020-12-26,"GM13","Free State of Saxony","quantile","0.5",24005.0660146
+2020-12-07,"4 wk ahead inc case",2021-01-02,"GM13","Free State of Saxony","quantile","0.5",26914.0574756
+2020-12-07,"-1 wk ahead cum case",2020-11-28,"GM13","Free State of Saxony","observed",NA,52451
+2020-12-07,"0 wk ahead cum case",2020-12-05,"GM13","Free State of Saxony","observed",NA,65870
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","point",NA,88344.0753156
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","point",NA,116401.3121477
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","point",NA,151164.1536266
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","point",NA,192783.273195
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.01",82362.0211375
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.01",104206.9753732
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.01",131637.3000806
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.01",164654.8483842
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.025",83250.2423367
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.025",106022.9726012
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.025",134540.6969841
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.025",168827.5386293
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.05",84039.7107934
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.05",107620.8273534
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.05",137076.1034018
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.05",172481.8340449
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.1",84954.9214184
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.1",109492.0698609
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.1",140068.4740928
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.1",176771.7373338
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.15",85582.9943799
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.15",110770.3234504
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.15",142123.747262
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.15",179733.2911057
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.2",86086.965655
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.2",111800.4871764
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.2",143779.0510946
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.2",182120.0288227
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.25",86526.3874958
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.25",112697.6218396
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.25",145215.4529283
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.25",184187.587618
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.3",86926.5721088
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.3",113509.6441334
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.3",146515.9259435
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.3",186065.3049893
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.35",87295.7848111
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.35",114262.9756277
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.35",147726.9789853
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.35",187817.8797401
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.4",87651.3216769
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.4",114987.8170505
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.4",148893.8344051
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.4",189503.462296
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.45",87997.3162441
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.45",115694.3416273
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.45",150029.5641758
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.45",191144.4280113
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.5",88344.0753156
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.5",116401.3121477
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.5",151164.1536266
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.5",192783.273195
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.55",88691.663938
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.55",117106.8511671
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.55",152296.0120837
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.55",194422.9438853
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.6",89047.6963888
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.6",117828.1807655
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.6",153451.6899932
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.6",196099.3380601
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.65",89417.0675031
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.65",118580.4789351
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.65",154661.4364146
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.65",197856.1922886
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.7",89805.5974461
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.7",119376.0329836
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.7",155941.4097158
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.7",199709.9841998
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.75",90228.7781459
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.75",120241.7917656
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.75",157332.2312682
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.75",201732.9727721
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.8",90703.2713821
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.8",121211.4427942
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.8",158893.7270989
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.8",204010.4676127
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.85",91267.6255307
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.85",122356.0857451
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.85",160729.6979167
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.85",206692.3344265
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.9",91984.8517442
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.9",123813.7685718
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.9",163083.1952328
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.9",210125.2346514
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.95",93059.7569201
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.95",126002.1146839
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.95",166617.9417136
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.95",215291.4444256
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.975",94004.5950323
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.975",127932.4959335
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.975",169725.7306124
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.975",219837.145176
+2020-12-07,"1 wk ahead cum case",2020-12-12,"GM13","Free State of Saxony","quantile","0.99",95148.5363699
+2020-12-07,"2 wk ahead cum case",2020-12-19,"GM13","Free State of Saxony","quantile","0.99",130254.9273558
+2020-12-07,"3 wk ahead cum case",2020-12-26,"GM13","Free State of Saxony","quantile","0.99",173480.7262654
+2020-12-07,"4 wk ahead cum case",2021-01-02,"GM13","Free State of Saxony","quantile","0.99",225306.9504954

--- a/data-processed/LeipzigIMISE-SECIR/2020-12-07-Germany-LeipzigIMISE-SECIR.csv
+++ b/data-processed/LeipzigIMISE-SECIR/2020-12-07-Germany-LeipzigIMISE-SECIR.csv
@@ -1,0 +1,1837 @@
+"forecast_date","target","target_end_date","location","location_name","type","quantile","value"
+2020-12-07,"-1 day ahead inc death",2020-12-06,"GM","Germany","observed",NA,255
+2020-12-07,"0 day ahead inc death",2020-12-07,"GM","Germany","observed",NA,147
+2020-12-07,"-1 day ahead cum death",2020-12-06,"GM","Germany","observed",NA,18781
+2020-12-07,"0 day ahead cum death",2020-12-07,"GM","Germany","observed",NA,18928
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","point",NA,146.8117597
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","point",NA,147.238082
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","point",NA,147.1751373
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","point",NA,147.3093587
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","point",NA,147.6066901
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","point",NA,147.6094328
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","point",NA,147.9016441
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","point",NA,147.6228717
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","point",NA,147.6488359
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","point",NA,147.7726068
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","point",NA,147.74391
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","point",NA,147.8814495
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","point",NA,147.9312623
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","point",NA,147.7249052
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","point",NA,147.7215369
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","point",NA,147.5898719
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","point",NA,147.3757194
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","point",NA,147.4547886
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","point",NA,147.1904084
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","point",NA,147.2625262
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","point",NA,146.7353074
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","point",NA,146.6464141
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","point",NA,146.2943909
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","point",NA,146.1042952
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","point",NA,145.7229534
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","point",NA,145.7121437
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","point",NA,145.1023105
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","point",NA,144.8679335
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","point",NA,144.4741417
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","point",NA,144.0500408
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.01",70.8583679
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.01",71.1693442
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.01",71.1803148
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.01",71.0398375
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.01",71.6287116
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.01",71.5726613
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.01",71.7628919
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.01",71.6588579
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.01",71.4622172
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.01",71.4744861
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.01",71.7881091
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.01",71.5304401
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.01",71.3398233
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.01",71.6324302
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.01",70.6557039
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.01",71.356369
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.01",71.396031
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.01",70.5372233
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.01",70.786535
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.01",70.4699674
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.01",69.8874497
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.01",69.661488
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.01",70.0371121
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.01",69.3137703
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.01",69.0496406
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.01",69.0420787
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.01",67.9936127
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.01",68.5090859
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.01",67.8137739
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.01",67.3569566
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.025",81.0322527
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.025",81.4171979
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.025",81.0741921
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.025",81.6269764
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.025",81.899902
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.025",81.9410909
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.025",81.9379149
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.025",82.049826
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.025",81.8269779
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.025",81.7820943
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.025",81.7927866
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.025",82.1140864
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.025",81.5371556
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.025",81.8003766
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.025",81.0426217
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.025",81.5014781
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.025",81.3583009
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.025",80.6485543
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.025",80.5207041
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.025",80.6862927
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.025",80.0885023
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.025",80.0883984
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.025",80.1385713
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.025",79.2613526
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.025",79.4783169
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.025",79.2974759
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.025",78.3428431
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.025",78.4165707
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.025",77.8170846
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.025",77.5823299
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.05",90.2868376
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.05",90.7262156
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.05",90.4684903
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.05",91.0343339
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.05",91.1723362
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.05",91.4658215
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.05",90.9957596
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.05",91.3311677
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.05",91.022481
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.05",91.1949944
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.05",91.0103001
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.05",91.1871134
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.05",90.9504453
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.05",91.1822245
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.05",90.5735853
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.05",90.8079547
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.05",90.481381
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.05",90.0688204
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.05",90.2268169
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.05",90.1218176
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.05",89.5799514
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.05",89.5171033
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.05",89.2116004
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.05",88.6621334
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.05",88.9205608
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.05",88.4731132
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.05",87.7455358
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.05",87.7235513
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.05",87.1600801
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.05",86.760673
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.1",101.6173429
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.1",101.9082975
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.1",101.6759662
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.1",102.2912554
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.1",102.4330112
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.1",102.5590828
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.1",102.3590067
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.1",102.4111355
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.1",102.2712544
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.1",102.6389721
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.1",102.3456346
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.1",102.5572832
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.1",102.3082738
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.1",102.5524759
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.1",102.165405
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.1",102.1315927
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.1",101.8228791
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.1",101.694837
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.1",101.460907
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.1",101.6465169
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.1",100.9669238
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.1",100.9271173
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.1",100.8623433
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.1",100.1660782
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.1",100.0509005
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.1",99.9901661
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.1",99.2327267
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.1",98.9913742
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.1",98.4485789
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.1",98.2440054
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.15",109.6368509
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.15",109.914061
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.15",109.6520003
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.15",110.2368174
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.15",110.3913231
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.15",110.4785354
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.15",110.337328
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.15",110.4422785
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.15",110.2639795
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.15",110.6699787
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.15",110.436446
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.15",110.4169938
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.15",110.4648952
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.15",110.3795507
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.15",110.0028511
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.15",109.9991824
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.15",109.8058526
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.15",109.6671837
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.15",109.6806624
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.15",109.7188214
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.15",109.0086208
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.15",109.1016427
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.15",108.8697216
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.15",108.4206009
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.15",108.1387349
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.15",107.8684298
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.15",107.3187787
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.15",107.1411255
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.15",106.602664
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.15",106.5045255
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.2",116.2210288
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.2",116.5627301
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.2",116.4333323
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.2",116.862062
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.2",117.0809487
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.2",116.9703544
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.2",117.020387
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.2",116.9761855
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.2",116.8650279
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.2",117.2183519
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.2",116.9188145
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.2",117.0687689
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.2",116.9751303
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.2",116.9323701
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.2",116.7520624
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.2",116.6463735
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.2",116.5993059
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.2",116.4210464
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.2",116.2583103
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.2",116.3677307
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.2",115.6430824
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.2",115.5980365
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.2",115.3423901
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.2",115.0245413
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.2",114.7564493
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.2",114.4619671
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.2",113.9418234
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.2",113.6633204
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.2",113.2606773
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.2",113.0580767
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.25",122.12278
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.25",122.4828097
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.25",122.283553
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.25",122.6263076
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.25",122.9454563
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.25",122.8348032
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.25",122.8838989
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.25",122.8222817
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.25",122.7545176
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.25",122.9695198
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.25",122.8472136
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.25",122.8137747
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.25",122.9312251
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.25",122.7429948
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.25",122.6402683
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.25",122.5770676
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.25",122.4084758
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.25",122.3067963
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.25",122.1181995
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.25",122.2295509
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.25",121.522303
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.25",121.4403774
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.25",121.2243478
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.25",121.0208225
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.25",120.7559796
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.25",120.33687
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.25",119.7816283
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.25",119.5055481
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.25",119.2186574
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.25",118.8514646
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.3",127.388421
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.3",127.8173365
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.3",127.746033
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.3",127.8844083
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.3",128.2057772
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.3",128.0119607
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.3",128.1823178
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.3",128.1378991
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.3",128.0562682
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.3",128.2683067
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.3",128.2547824
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.3",128.163445
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.3",128.3223136
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.3",128.0745738
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.3",128.0880514
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.3",127.9628639
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.3",127.765908
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.3",127.6684177
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.3",127.5615472
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.3",127.5263842
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.3",126.8953719
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.3",126.833525
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.3",126.5733303
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.3",126.2877403
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.3",126.18957
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.3",125.7372048
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.3",125.2631153
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.3",124.9189515
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.3",124.69759
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.3",124.2884499
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.35",132.4491087
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.35",132.7545907
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.35",132.673406
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.35",132.9762175
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.35",133.1265102
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.35",133.0307184
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.35",133.2771259
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.35",133.1623125
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.35",133.0261691
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.35",133.3705052
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.35",133.3982976
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.35",133.2399608
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.35",133.5302607
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.35",133.1516806
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.35",133.1267506
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.35",132.9871072
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.35",132.8093783
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.35",132.793912
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.35",132.5626385
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.35",132.5382482
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.35",132.0776407
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.35",131.9157132
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.35",131.6654201
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.35",131.4073385
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.35",131.2203901
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.35",130.8100071
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.35",130.4482281
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.35",129.9769958
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.35",129.8045117
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.35",129.4092868
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.4",137.291121
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.4",137.6686432
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.4",137.4665347
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.4",137.8203867
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.4",137.8997134
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.4",137.9826226
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.4",138.3068854
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.4",138.0385651
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.4",137.9508236
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.4",138.2927381
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.4",138.2090107
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.4",138.114364
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.4",138.4616574
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.4",138.168649
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.4",137.9825624
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.4",137.8309993
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.4",137.7403035
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.4",137.8602063
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.4",137.5726303
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.4",137.5267058
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.4",137.10047
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.4",136.8424212
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.4",136.5760242
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.4",136.3660917
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.4",136.2041781
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.4",135.8662145
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.4",135.3178253
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.4",134.9864888
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.4",134.720499
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.4",134.4394972
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.45",142.1382657
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.45",142.5005662
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.45",142.3159284
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.45",142.6023472
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.45",142.8143655
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.45",142.7982178
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.45",143.1180483
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.45",142.8830249
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.45",142.8644922
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.45",142.9832175
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.45",142.9917319
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.45",143.0351863
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.45",143.280662
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.45",142.9092068
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.45",142.8163633
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.45",142.6976656
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.45",142.5130415
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.45",142.7241466
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.45",142.4225193
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.45",142.3388438
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.45",141.8845854
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.45",141.7698384
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.45",141.3503298
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.45",141.2424779
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.45",140.8197992
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.45",140.8300955
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.45",140.1624247
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.45",139.8553924
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.45",139.6669084
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.45",139.2505751
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.5",146.8117597
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.5",147.238082
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.5",147.1751373
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.5",147.3093587
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.5",147.6066901
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.5",147.6094328
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.5",147.9016441
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.5",147.6228717
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.5",147.6488359
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.5",147.7726068
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.5",147.74391
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.5",147.8814495
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.5",147.9312623
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.5",147.7249052
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.5",147.7215369
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.5",147.5898719
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.5",147.3757194
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.5",147.4547886
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.5",147.1904084
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.5",147.2625262
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.5",146.7353074
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.5",146.6464141
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.5",146.2943909
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.5",146.1042952
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.5",145.7229534
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.5",145.7121437
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.5",145.1023105
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.5",144.8679335
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.5",144.4741417
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.5",144.0500408
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.55",151.6906882
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.55",152.1061892
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.55",152.1302857
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.55",152.2253084
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.55",152.6138303
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.55",152.4434183
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.55",152.7843173
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.55",152.6426618
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.55",152.5428844
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.55",152.6278827
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.55",152.6163984
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.55",152.759535
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.55",152.9344402
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.55",152.5723316
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.55",152.6775703
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.55",152.4680329
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.55",152.3849104
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.55",152.3179761
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.55",152.2220401
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.55",152.0477545
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.55",151.678482
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.55",151.531127
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.55",151.1659612
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.55",151.0036612
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.55",150.6412042
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.55",150.718315
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.55",150.1059534
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.55",149.8465223
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.55",149.4016311
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.55",149.1221559
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.6",156.8143437
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.6",157.1016807
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.6",157.0716416
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.6",157.2907686
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.6",157.604773
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.6",157.5454684
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.6",157.7670422
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.6",157.6122249
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.6",157.6851415
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.6",157.6374949
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.6",157.6720011
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.6",157.7495448
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.6",158.0714713
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.6",157.567558
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.6",157.7999122
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.6",157.4419995
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.6",157.5431234
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.6",157.4273697
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.6",157.3892543
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.6",157.1620967
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.6",156.722094
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.6",156.6731542
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.6",156.1884815
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.6",156.2143198
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.6",155.7290119
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.6",155.8293213
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.6",155.4343008
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.6",154.9575284
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.6",154.5132122
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.6",154.164877
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.65",162.1400937
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.65",162.4103606
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.65",162.4419113
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.65",162.5255077
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.65",162.9329689
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.65",162.8475051
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.65",163.0241114
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.65",162.8975272
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.65",162.9614521
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.65",162.9628867
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.65",162.9584207
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.65",163.0474833
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.65",163.365645
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.65",162.9417339
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.65",163.1010929
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.65",162.8164317
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.65",162.8801602
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.65",162.7348112
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.65",162.8014455
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.65",162.514868
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.65",162.0961772
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.65",161.99213
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.65",161.5759063
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.65",161.662096
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.65",161.1830683
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.65",161.2247382
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.65",160.8440696
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.65",160.465247
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.65",159.881742
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.65",159.5844294
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.7",167.7820783
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.7",168.1716733
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.7",168.2525588
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.7",168.1203186
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.7",168.7040892
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.7",168.4971107
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.7",168.7399807
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.7",168.7036705
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.7",168.7210799
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.7",168.7275601
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.7",168.6181292
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.7",168.7019588
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.7",168.9031034
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.7",168.6109211
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.7",168.930003
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.7",168.6796295
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.7",168.5736874
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.7",168.5632324
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.7",168.5372368
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.7",168.296782
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.7",167.8363952
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.7",167.7609656
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.7",167.4599018
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.7",167.4891189
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.7",166.8917186
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.7",166.986872
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.7",166.6624757
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.7",166.283443
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.7",165.7132764
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.7",165.4622068
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.75",173.8711414
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.75",174.3284944
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.75",174.5500999
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.75",174.3106762
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.75",175.03031
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.75",174.7148354
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.75",175.0533251
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.75",174.8824436
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.75",174.9785501
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.75",175.0226382
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.75",174.9911126
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.75",174.9944123
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.75",175.1272275
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.75",174.8812625
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.75",175.2153181
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.75",174.8270244
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.75",175.0147069
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.75",174.8476365
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.75",174.853873
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.75",174.7276364
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.75",174.2723416
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.75",174.0243379
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.75",173.8126216
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.75",173.9423797
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.75",173.2615943
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.75",173.2527842
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.75",173.1955874
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.75",172.6655289
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.75",171.9750264
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.75",171.7016949
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.8",180.8612476
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.8",181.5314565
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.8",181.6124013
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.8",181.5038973
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.8",182.04444
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.8",181.7494017
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.8",182.0745932
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.8",181.9551138
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.8",182.052374
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.8",182.0408846
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.8",182.1891856
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.8",182.0466451
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.8",182.1560935
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.8",182.0905784
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.8",182.3258928
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.8",181.903132
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.8",182.0101334
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.8",182.1470102
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.8",182.012817
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.8",181.9396164
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.8",181.597178
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.8",181.339071
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.8",181.2216034
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.8",181.1251042
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.8",180.5865759
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.8",180.429838
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.8",180.3791479
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.8",179.7753625
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.8",179.0638766
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.8",178.8883752
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.85",189.3284232
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.85",189.8682287
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.85",190.0117724
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.85",189.7965771
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.85",190.4497509
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.85",190.1355937
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.85",190.3807156
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.85",190.367845
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.85",190.534134
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.85",190.4792808
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.85",190.6195218
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.85",190.5648658
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.85",190.7693315
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.85",190.7704713
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.85",190.8494788
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.85",190.3950244
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.85",190.4488505
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.85",190.630617
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.85",190.4563846
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.85",190.4860514
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.85",190.3750701
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.85",189.8695685
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.85",189.8730609
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.85",189.6231708
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.85",189.1645676
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.85",189.1805857
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.85",188.8935572
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.85",188.2348611
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.85",187.7780923
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.85",187.3900396
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.9",200.3136622
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.9",200.7278094
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.9",200.7449954
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.9",200.6987354
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.9",201.2628076
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.9",200.971669
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.9",201.2888835
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.9",201.3021052
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.9",201.3090815
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.9",201.617583
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.9",201.5076483
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.9",201.2576537
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.9",201.8653089
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.9",201.644512
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.9",201.7963838
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.9",201.7664683
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.9",201.5884747
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.9",201.4994646
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.9",201.4758349
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.9",201.5087251
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.9",201.4840634
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.9",200.9390649
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.9",200.8465738
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.9",200.6083821
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.9",200.557134
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.9",200.1746732
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.9",199.9933075
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.9",199.6010399
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.9",199.0038767
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.9",198.5113101
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.95",216.8807244
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.95",217.5592245
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.95",217.3098755
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.95",217.1845802
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.95",217.7147181
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.95",217.8475942
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.95",218.0466709
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.95",217.5883585
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.95",217.7802953
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.95",218.4535017
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.95",218.2438013
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.95",218.1902345
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.95",218.9066735
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.95",218.6492595
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.95",218.421442
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.95",218.9246364
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.95",218.6847515
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.95",218.3668218
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.95",218.4867962
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.95",218.5433295
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.95",218.4281398
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.95",217.6554153
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.95",217.8600067
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.95",217.8923553
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.95",217.9882549
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.95",216.8486126
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.95",216.8074854
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.95",216.8673992
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.95",216.1334241
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.95",215.8267191
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.975",232.2252438
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.975",232.7773504
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.975",232.4155623
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.975",232.3453035
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.975",233.1437182
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.975",231.8996601
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.975",232.9070071
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.975",232.3624502
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.975",232.5583791
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.975",233.2520349
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.975",233.4383593
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.975",233.0014219
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.975",234.1346757
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.975",233.8241075
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.975",233.2139086
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.975",233.6140968
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.975",234.0234615
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.975",233.4987137
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.975",233.5130033
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.975",233.6531461
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.975",233.5120548
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.975",232.6967933
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.975",233.2383107
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.975",232.4284276
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.975",233.5428991
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.975",231.8930327
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.975",232.2009782
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.975",232.2633964
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.975",231.6999399
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.975",230.6134542
+2020-12-07,"1 day ahead inc death",2020-12-08,"GM","Germany","quantile","0.99",250.1156513
+2020-12-07,"2 day ahead inc death",2020-12-09,"GM","Germany","quantile","0.99",250.9734076
+2020-12-07,"3 day ahead inc death",2020-12-10,"GM","Germany","quantile","0.99",250.5896203
+2020-12-07,"4 day ahead inc death",2020-12-11,"GM","Germany","quantile","0.99",250.8063997
+2020-12-07,"5 day ahead inc death",2020-12-12,"GM","Germany","quantile","0.99",250.7855501
+2020-12-07,"6 day ahead inc death",2020-12-13,"GM","Germany","quantile","0.99",250.8433792
+2020-12-07,"7 day ahead inc death",2020-12-14,"GM","Germany","quantile","0.99",250.6508771
+2020-12-07,"8 day ahead inc death",2020-12-15,"GM","Germany","quantile","0.99",250.381308
+2020-12-07,"9 day ahead inc death",2020-12-16,"GM","Germany","quantile","0.99",250.6027751
+2020-12-07,"10 day ahead inc death",2020-12-17,"GM","Germany","quantile","0.99",251.3882785
+2020-12-07,"11 day ahead inc death",2020-12-18,"GM","Germany","quantile","0.99",252.2317517
+2020-12-07,"12 day ahead inc death",2020-12-19,"GM","Germany","quantile","0.99",251.31991
+2020-12-07,"13 day ahead inc death",2020-12-20,"GM","Germany","quantile","0.99",252.298228
+2020-12-07,"14 day ahead inc death",2020-12-21,"GM","Germany","quantile","0.99",252.8272173
+2020-12-07,"15 day ahead inc death",2020-12-22,"GM","Germany","quantile","0.99",251.1399499
+2020-12-07,"16 day ahead inc death",2020-12-23,"GM","Germany","quantile","0.99",251.4491726
+2020-12-07,"17 day ahead inc death",2020-12-24,"GM","Germany","quantile","0.99",252.8055584
+2020-12-07,"18 day ahead inc death",2020-12-25,"GM","Germany","quantile","0.99",252.2019775
+2020-12-07,"19 day ahead inc death",2020-12-26,"GM","Germany","quantile","0.99",251.4102656
+2020-12-07,"20 day ahead inc death",2020-12-27,"GM","Germany","quantile","0.99",253.2088909
+2020-12-07,"21 day ahead inc death",2020-12-28,"GM","Germany","quantile","0.99",251.4451593
+2020-12-07,"22 day ahead inc death",2020-12-29,"GM","Germany","quantile","0.99",251.6061044
+2020-12-07,"23 day ahead inc death",2020-12-30,"GM","Germany","quantile","0.99",251.5232719
+2020-12-07,"24 day ahead inc death",2020-12-31,"GM","Germany","quantile","0.99",251.3429785
+2020-12-07,"25 day ahead inc death",2021-01-01,"GM","Germany","quantile","0.99",252.1302981
+2020-12-07,"26 day ahead inc death",2021-01-02,"GM","Germany","quantile","0.99",251.0381125
+2020-12-07,"27 day ahead inc death",2021-01-03,"GM","Germany","quantile","0.99",250.9732327
+2020-12-07,"28 day ahead inc death",2021-01-04,"GM","Germany","quantile","0.99",250.4273015
+2020-12-07,"29 day ahead inc death",2021-01-05,"GM","Germany","quantile","0.99",250.387396
+2020-12-07,"30 day ahead inc death",2021-01-06,"GM","Germany","quantile","0.99",249.5300453
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","point",NA,19074.8117597
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","point",NA,19222.0498417
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","point",NA,19369.224979
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","point",NA,19516.5343377
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","point",NA,19664.1410278
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","point",NA,19811.7504606
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","point",NA,19959.6521048
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","point",NA,20107.2749764
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","point",NA,20254.9238124
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","point",NA,20402.6964192
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","point",NA,20550.4403292
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","point",NA,20698.3217786
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","point",NA,20846.2530409
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","point",NA,20993.9779461
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","point",NA,21141.6994831
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","point",NA,21289.289355
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","point",NA,21436.6650744
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","point",NA,21584.119863
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","point",NA,21731.3102714
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","point",NA,21878.5727976
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","point",NA,22025.308105
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","point",NA,22171.9545192
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","point",NA,22318.2489101
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","point",NA,22464.3532053
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","point",NA,22610.0761587
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","point",NA,22755.7883024
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","point",NA,22900.8906129
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","point",NA,23045.7585464
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","point",NA,23190.2326882
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","point",NA,23334.282729
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.01",18998.8583679
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.01",19070.027712
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.01",19141.2080269
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.01",19212.2478644
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.01",19283.876576
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.01",19355.4492373
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.01",19427.2121293
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.01",19498.8709872
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.01",19570.3332044
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.01",19641.8076905
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.01",19713.5957997
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.01",19785.1262398
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.01",19856.4660631
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.01",19928.0984933
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.01",19998.7541972
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.01",20070.1105662
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.01",20141.5065972
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.01",20212.0438205
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.01",20282.8303556
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.01",20353.3003229
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.01",20423.1877726
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.01",20492.8492606
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.01",20562.8863727
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.01",20632.200143
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.01",20701.2497836
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.01",20770.2918624
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.01",20838.2854751
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.01",20906.7945609
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.01",20974.6083348
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.01",21041.9652914
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.025",19009.0322527
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.025",19090.4494507
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.025",19171.5236427
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.025",19253.1506192
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.025",19335.0505212
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.025",19416.9916121
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.025",19498.929527
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.025",19580.9793529
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.025",19662.8063308
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.025",19744.5884251
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.025",19826.3812117
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.025",19908.4952982
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.025",19990.0324537
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.025",20071.8328304
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.025",20152.875452
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.025",20234.3769302
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.025",20315.7352311
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.025",20396.3837853
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.025",20476.9044894
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.025",20557.5907821
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.025",20637.6792845
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.025",20717.7676828
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.025",20797.9062542
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.025",20877.1676068
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.025",20956.6459237
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.025",21035.9433996
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.025",21114.2862427
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.025",21192.7028134
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.025",21270.519898
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.025",21348.102228
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.05",19018.2868376
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.05",19109.0130532
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.05",19199.4815435
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.05",19290.5158774
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.05",19381.6882136
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.05",19473.154035
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.05",19564.1497946
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.05",19655.4809624
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.05",19746.5034434
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.05",19837.6984378
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.05",19928.7087378
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.05",20019.8958513
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.05",20110.8462966
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.05",20202.0285211
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.05",20292.6021064
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.05",20383.410061
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.05",20473.8914421
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.05",20563.9602625
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.05",20654.1870794
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.05",20744.308897
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.05",20833.8888484
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.05",20923.4059517
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.05",21012.6175521
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.05",21101.2796855
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.05",21190.2002463
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.05",21278.6733595
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.05",21366.4188954
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.05",21454.1424466
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.05",21541.3025267
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.05",21628.0631997
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.1",19029.6173429
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.1",19131.5256404
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.1",19233.2016066
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.1",19335.492862
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.1",19437.9258731
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.1",19540.484956
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.1",19642.8439627
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.1",19745.2550981
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.1",19847.5263525
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.1",19950.1653246
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.1",20052.5109592
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.1",20155.0682423
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.1",20257.3765161
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.1",20359.928992
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.1",20462.0943971
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.1",20564.2259898
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.1",20666.0488688
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.1",20767.7437058
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.1",20869.2046128
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.1",20970.8511297
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.1",21071.8180535
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.1",21172.7451708
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.1",21273.6075142
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.1",21373.7735924
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.1",21473.8244929
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.1",21573.8146591
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.1",21673.0473858
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.1",21772.03876
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.1",21870.4873388
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.1",21968.7313443
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.15",19037.6368509
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.15",19147.5509119
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.15",19257.2029122
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.15",19367.4397295
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.15",19477.8310526
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.15",19588.309588
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.15",19698.646916
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.15",19809.0891945
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.15",19919.353174
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.15",20030.0231526
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.15",20140.4595986
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.15",20250.8765924
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.15",20361.3414876
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.15",20471.7210383
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.15",20581.7238893
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.15",20691.7230717
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.15",20801.5289242
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.15",20911.1961079
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.15",21020.8767703
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.15",21130.5955917
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.15",21239.6042125
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.15",21348.7058552
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.15",21457.5755767
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.15",21565.9961776
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.15",21674.1349126
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.15",21782.0033424
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.15",21889.322121
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.15",21996.4632465
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.15",22103.0659104
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.15",22209.570436
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.2",19044.2210288
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.2",19160.7837589
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.2",19277.2170912
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.2",19394.0791532
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.2",19511.1601019
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.2",19628.1304563
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.2",19745.1508433
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.2",19862.1270288
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.2",19978.9920567
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.2",20096.2104085
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.2",20213.1292231
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.2",20330.1979919
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.2",20447.1731223
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.2",20564.1054924
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.2",20680.8575548
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.2",20797.5039283
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.2",20914.1032342
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.2",21030.5242806
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.2",21146.7825909
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.2",21263.1503216
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.2",21378.793404
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.2",21494.3914404
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.2",21609.7338306
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.2",21724.7583719
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.2",21839.5148212
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.2",21953.9767882
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.2",22067.9186117
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.2",22181.5819321
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.2",22294.8426093
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.2",22407.9006861
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.25",19050.12278
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.25",19172.6055896
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.25",19294.8891426
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.25",19417.5154502
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.25",19540.4609065
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.25",19663.2957097
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.25",19786.1796085
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.25",19909.0018902
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.25",20031.7564078
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.25",20154.7259276
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.25",20277.5731412
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.25",20400.3869158
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.25",20523.318141
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.25",20646.0611357
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.25",20768.701404
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.25",20891.2784716
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.25",21013.6869474
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.25",21135.9937437
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.25",21258.1119432
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.25",21380.3414941
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.25",21501.8637971
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.25",21623.3041745
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.25",21744.5285224
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.25",21865.5493448
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.25",21986.3053244
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.25",22106.6421944
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.25",22226.4238227
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.25",22345.9293708
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.25",22465.1480282
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.25",22583.9994927
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.3",19055.388421
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.3",19183.2057575
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.3",19310.9517905
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.3",19438.8361988
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.3",19567.041976
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.3",19695.0539367
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.3",19823.2362545
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.3",19951.3741536
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.3",20079.4304218
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.3",20207.6987285
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.3",20335.9535108
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.3",20464.1169558
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.3",20592.4392694
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.3",20720.5138433
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.3",20848.6018946
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.3",20976.5647585
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.3",21104.3306665
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.3",21231.9990842
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.3",21359.5606314
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.3",21487.0870156
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.3",21613.9823875
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.3",21740.8159125
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.3",21867.3892428
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.3",21993.6769831
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.3",22119.8665531
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.3",22245.6037579
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.3",22370.8668732
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.3",22495.7858246
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.3",22620.4834146
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.3",22744.7718644
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.35",19060.4491087
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.35",19193.2036994
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.35",19325.8771054
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.35",19458.8533229
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.35",19591.9798331
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.35",19725.0105516
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.35",19858.2876774
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.35",19991.4499899
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.35",20124.476159
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.35",20257.8466642
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.35",20391.2449618
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.35",20524.4849226
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.35",20658.0151833
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.35",20791.1668639
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.35",20924.2936145
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.35",21057.2807217
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.35",21190.0901
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.35",21322.884012
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.35",21455.4466505
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.35",21587.9848988
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.35",21720.0625394
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.35",21851.9782526
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.35",21983.6436727
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.35",22115.0510112
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.35",22246.2714013
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.35",22377.0814084
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.35",22507.5296365
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.35",22637.5066323
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.35",22767.3111439
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.35",22896.7204307
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.4",19065.291121
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.4",19202.9597643
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.4",19340.426299
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.4",19478.2466858
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.4",19616.1463992
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.4",19754.1290218
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.4",19892.4359072
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.4",20030.4744723
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.4",20168.4252959
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.4",20306.718034
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.4",20444.9270447
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.4",20583.0414087
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.4",20721.503066
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.4",20859.671715
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.4",20997.6542774
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.4",21135.4852767
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.4",21273.2255801
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.4",21411.0857865
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.4",21548.6584168
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.4",21686.1851226
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.4",21823.2855926
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.4",21960.1280138
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.4",22096.7040381
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.4",22233.0701298
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.4",22369.2743079
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.4",22505.1405224
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.4",22640.4583477
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.4",22775.4448364
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.4",22910.1653354
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.4",23044.6048327
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.45",19070.1382657
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.45",19212.6388319
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.45",19354.9547602
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.45",19497.5571075
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.45",19640.371473
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.45",19783.1696908
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.45",19926.2877391
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.45",20069.170764
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.45",20212.0352562
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.45",20355.0184736
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.45",20498.0102055
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.45",20641.0453918
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.45",20784.3260538
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.45",20927.2352606
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.45",21070.0516238
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.45",21212.7492894
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.45",21355.2623309
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.45",21497.9864775
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.45",21640.4089968
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.45",21782.7478406
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.45",21924.632426
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.45",22066.4022643
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.45",22207.7525942
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.45",22348.9950721
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.45",22489.8148712
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.45",22630.6449668
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.45",22770.8073915
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.45",22910.6627839
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.45",23050.3296923
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.45",23189.5802674
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.5",19074.8117597
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.5",19222.0498417
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.5",19369.224979
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.5",19516.5343377
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.5",19664.1410278
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.5",19811.7504606
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.5",19959.6521048
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.5",20107.2749764
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.5",20254.9238124
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.5",20402.6964192
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.5",20550.4403292
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.5",20698.3217786
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.5",20846.2530409
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.5",20993.9779461
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.5",21141.6994831
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.5",21289.289355
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.5",21436.6650744
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.5",21584.119863
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.5",21731.3102714
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.5",21878.5727976
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.5",22025.308105
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.5",22171.9545192
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.5",22318.2489101
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.5",22464.3532053
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.5",22610.0761587
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.5",22755.7883024
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.5",22900.8906129
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.5",23045.7585464
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.5",23190.2326882
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.5",23334.282729
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.55",19079.6906882
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.55",19231.7968774
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.55",19383.9271631
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.55",19536.1524715
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.55",19688.7663018
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.55",19841.2097201
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.55",19993.9940374
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.55",20146.6366992
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.55",20299.1795836
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.55",20451.8074663
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.55",20604.4238647
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.55",20757.1833997
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.55",20910.1178399
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.55",21062.6901715
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.55",21215.3677418
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.55",21367.8357747
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.55",21520.2206852
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.55",21672.5386612
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.55",21824.7607013
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.55",21976.8084558
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.55",22128.4869378
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.55",22280.0180648
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.55",22431.184026
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.55",22582.1876871
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.55",22732.8288914
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.55",22883.5472064
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.55",23033.6531598
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.55",23183.4996821
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.55",23332.9013132
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.55",23482.0234691
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.6",19084.8143437
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.6",19241.9160244
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.6",19398.987666
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.6",19556.2784346
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.6",19713.8832077
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.6",19871.4286761
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.6",20029.1957183
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.6",20186.8079432
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.6",20344.4930847
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.6",20502.1305796
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.6",20659.8025807
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.6",20817.5521255
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.6",20975.6235968
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.6",21133.1911548
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.6",21290.9910669
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.6",21448.4330664
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.6",21605.9761899
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.6",21763.4035596
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.6",21920.7928139
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.6",22077.9549106
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.6",22234.6770046
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.6",22391.3501588
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.6",22547.5386403
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.6",22703.7529601
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.6",22859.4819721
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.6",23015.3112934
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.6",23170.7455942
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.6",23325.7031226
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.6",23480.2163348
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.6",23634.3812118
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.65",19090.1400937
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.65",19252.5504543
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.65",19414.9923656
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.65",19577.5178733
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.65",19740.4508422
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.65",19903.2983472
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.65",20066.3224587
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.65",20229.2199859
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.65",20392.1814379
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.65",20555.1443247
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.65",20718.1027453
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.65",20881.1502287
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.65",21044.5158736
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.65",21207.4576076
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.65",21370.5587005
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.65",21533.3751322
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.65",21696.2552924
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.65",21858.9901036
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.65",22021.7915491
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.65",22184.3064171
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.65",22346.4025943
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.65",22508.3947243
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.65",22669.9706306
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.65",22831.6327266
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.65",22992.8157949
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.65",23154.040533
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.65",23314.8846026
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.65",23475.3498496
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.65",23635.2315916
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.65",23794.816021
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.7",19095.7820783
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.7",19263.9537517
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.7",19432.2063105
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.7",19600.3266291
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.7",19769.0307183
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.7",19937.5278291
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.7",20106.2678097
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.7",20274.9714803
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.7",20443.6925602
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.7",20612.4201203
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.7",20781.0382495
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.7",20949.7402083
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.7",21118.6433117
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.7",21287.2542328
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.7",21456.1842358
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.7",21624.8638653
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.7",21793.4375528
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.7",21962.0007852
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.7",22130.538022
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.7",22298.834804
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.7",22466.6711992
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.7",22634.4321648
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.7",22801.8920666
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.7",22969.3811855
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.7",23136.2729041
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.7",23303.2597761
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.7",23469.9222517
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.7",23636.2056947
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.7",23801.9189712
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.7",23967.381178
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.75",19101.8711414
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.75",19276.1996358
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.75",19450.7497358
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.75",19625.060412
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.75",19800.090722
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.75",19974.8055574
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.75",20149.8588826
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.75",20324.7413262
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.75",20499.7198763
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.75",20674.7425145
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.75",20849.7336271
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.75",21024.7280394
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.75",21199.8552669
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.75",21374.7365294
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.75",21549.9518475
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.75",21724.7788719
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.75",21899.7935788
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.75",22074.6412153
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.75",22249.4950884
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.75",22424.2227248
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.75",22598.4950664
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.75",22772.5194043
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.75",22946.3320259
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.75",23120.2744056
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.75",23293.5359999
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.75",23466.7887841
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.75",23639.9843715
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.75",23812.6499005
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.75",23984.6249269
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.75",24156.3266217
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.8",19108.8612476
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.8",19290.3927041
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.8",19472.0051054
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.8",19653.5090027
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.8",19835.5534426
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.8",20017.3028443
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.8",20199.3774375
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.8",20381.3325513
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.8",20563.3849253
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.8",20745.4258099
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.8",20927.6149955
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.8",21109.6616406
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.8",21291.8177341
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.8",21473.9083125
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.8",21656.2342053
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.8",21838.1373373
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.8",22020.1474707
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.8",22202.2944808
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.8",22384.3072978
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.8",22566.2469141
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.8",22747.8440921
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.8",22929.1831631
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.8",23110.4047666
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.8",23291.5298707
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.8",23472.1164466
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.8",23652.5462847
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.8",23832.9254326
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.8",24012.7007951
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.8",24191.7646717
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.8",24370.6530468
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.85",19117.3284232
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.85",19307.1966518
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.85",19497.2084242
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.85",19687.0050014
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.85",19877.4547522
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.85",20067.590346
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.85",20257.9710615
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.85",20448.3389066
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.85",20638.8730406
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.85",20829.3523214
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.85",21019.9718432
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.85",21210.536709
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.85",21401.3060405
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.85",21592.0765118
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.85",21782.9259906
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.85",21973.321015
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.85",22163.7698654
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.85",22354.4004825
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.85",22544.8568671
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.85",22735.3429185
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.85",22925.7179886
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.85",23115.5875571
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.85",23305.4606179
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.85",23495.0837887
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.85",23684.2483563
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.85",23873.4289419
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.85",24062.3224991
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.85",24250.5573601
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.85",24438.3354525
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.85",24625.7254921
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.9",19128.3136622
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.9",19329.0414716
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.9",19529.7864671
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.9",19730.4852025
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.9",19931.7480101
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.9",20132.7196791
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.9",20334.0085626
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.9",20535.3106678
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.9",20736.6197493
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.9",20938.2373323
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.9",21139.7449806
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.9",21341.0026343
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.9",21542.8679432
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.9",21744.5124553
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.9",21946.3088391
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.9",22148.0753074
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.9",22349.6637821
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.9",22551.1632467
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.9",22752.6390816
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.9",22954.1478067
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.9",23155.6318701
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.9",23356.570935
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.9",23557.4175088
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.9",23758.0258909
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.9",23958.5830248
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.9",24158.757698
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.9",24358.7510054
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.9",24558.3520453
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.9",24757.355922
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.9",24955.8672321
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.95",19144.8807244
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.95",19362.4399489
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.95",19579.7498244
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.95",19796.9344045
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.95",20014.6491227
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.95",20232.4967168
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.95",20450.5433877
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.95",20668.1317462
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.95",20885.9120415
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.95",21104.3655432
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.95",21322.6093444
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.95",21540.7995789
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.95",21759.7062524
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.95",21978.3555119
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.95",22196.7769539
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.95",22415.7015903
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.95",22634.3863418
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.95",22852.7531636
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.95",23071.2399599
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.95",23289.7832893
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.95",23508.2114291
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.95",23725.8668444
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.95",23943.7268511
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.95",24161.6192064
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.95",24379.6074612
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.95",24596.4560739
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.95",24813.2635592
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.95",25030.1309585
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.95",25246.2643826
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.95",25462.0911017
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.975",19160.2252438
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.975",19393.0025942
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.975",19625.4181565
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.975",19857.76346
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.975",20090.9071782
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.975",20322.8068384
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.975",20555.7138455
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.975",20788.0762957
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.975",21020.6346747
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.975",21253.8867097
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.975",21487.325069
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.975",21720.3264909
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.975",21954.4611665
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.975",22188.285274
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.975",22421.4991827
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.975",22655.1132795
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.975",22889.136741
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.975",23122.6354547
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.975",23356.148458
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.975",23589.8016041
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.975",23823.3136589
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.975",24056.0104521
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.975",24289.2487628
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.975",24521.6771905
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.975",24755.2200896
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.975",24987.1131223
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.975",25219.3141005
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.975",25451.5774969
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.975",25683.2774368
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.975",25913.8908911
+2020-12-07,"1 day ahead cum death",2020-12-08,"GM","Germany","quantile","0.99",19178.1156513
+2020-12-07,"2 day ahead cum death",2020-12-09,"GM","Germany","quantile","0.99",19429.0890589
+2020-12-07,"3 day ahead cum death",2020-12-10,"GM","Germany","quantile","0.99",19679.6786792
+2020-12-07,"4 day ahead cum death",2020-12-11,"GM","Germany","quantile","0.99",19930.4850788
+2020-12-07,"5 day ahead cum death",2020-12-12,"GM","Germany","quantile","0.99",20181.2706289
+2020-12-07,"6 day ahead cum death",2020-12-13,"GM","Germany","quantile","0.99",20432.1140081
+2020-12-07,"7 day ahead cum death",2020-12-14,"GM","Germany","quantile","0.99",20682.7648852
+2020-12-07,"8 day ahead cum death",2020-12-15,"GM","Germany","quantile","0.99",20933.1461933
+2020-12-07,"9 day ahead cum death",2020-12-16,"GM","Germany","quantile","0.99",21183.7489683
+2020-12-07,"10 day ahead cum death",2020-12-17,"GM","Germany","quantile","0.99",21435.1372468
+2020-12-07,"11 day ahead cum death",2020-12-18,"GM","Germany","quantile","0.99",21687.3689986
+2020-12-07,"12 day ahead cum death",2020-12-19,"GM","Germany","quantile","0.99",21938.6889086
+2020-12-07,"13 day ahead cum death",2020-12-20,"GM","Germany","quantile","0.99",22190.9871366
+2020-12-07,"14 day ahead cum death",2020-12-21,"GM","Germany","quantile","0.99",22443.8143539
+2020-12-07,"15 day ahead cum death",2020-12-22,"GM","Germany","quantile","0.99",22694.9543038
+2020-12-07,"16 day ahead cum death",2020-12-23,"GM","Germany","quantile","0.99",22946.4034763
+2020-12-07,"17 day ahead cum death",2020-12-24,"GM","Germany","quantile","0.99",23199.2090347
+2020-12-07,"18 day ahead cum death",2020-12-25,"GM","Germany","quantile","0.99",23451.4110123
+2020-12-07,"19 day ahead cum death",2020-12-26,"GM","Germany","quantile","0.99",23702.8212779
+2020-12-07,"20 day ahead cum death",2020-12-27,"GM","Germany","quantile","0.99",23956.0301688
+2020-12-07,"21 day ahead cum death",2020-12-28,"GM","Germany","quantile","0.99",24207.4753281
+2020-12-07,"22 day ahead cum death",2020-12-29,"GM","Germany","quantile","0.99",24459.0814325
+2020-12-07,"23 day ahead cum death",2020-12-30,"GM","Germany","quantile","0.99",24710.6047044
+2020-12-07,"24 day ahead cum death",2020-12-31,"GM","Germany","quantile","0.99",24961.9476829
+2020-12-07,"25 day ahead cum death",2021-01-01,"GM","Germany","quantile","0.99",25214.0779809
+2020-12-07,"26 day ahead cum death",2021-01-02,"GM","Germany","quantile","0.99",25465.1160934
+2020-12-07,"27 day ahead cum death",2021-01-03,"GM","Germany","quantile","0.99",25716.0893261
+2020-12-07,"28 day ahead cum death",2021-01-04,"GM","Germany","quantile","0.99",25966.5166277
+2020-12-07,"29 day ahead cum death",2021-01-05,"GM","Germany","quantile","0.99",26216.9040237
+2020-12-07,"30 day ahead cum death",2021-01-06,"GM","Germany","quantile","0.99",26466.434069
+2020-12-07,"-1 wk ahead inc death",2020-11-28,"GM","Germany","observed",NA,2081
+2020-12-07,"0 wk ahead inc death",2020-12-05,"GM","Germany","observed",NA,2552
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.01",2015.1914335
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.01",2004.4078428
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.01",1984.4871675
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.01",1948.7461216
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.025",2095.9155767
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.025",2087.1527267
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.025",2067.3332875
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.025",2027.848322
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.05",2166.2918917
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.05",2160.6665966
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.05",2141.8680619
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.05",2101.4168812
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.1",2249.8359866
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.1",2246.6592846
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.1",2225.4225954
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.1",2186.838368
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.15",2307.8857537
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.15",2305.0056094
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.15",2283.564747
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.15",2245.5221344
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.2",2355.0455704
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.2",2350.9627571
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.2",2331.3554601
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.2",2293.3369262
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.25",2395.1545286
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.25",2391.9706933
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.25",2372.5824095
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.25",2333.5525994
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.3",2432.036798
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.3",2428.9829784
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.3",2408.9626696
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.3",2371.0953735
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.35",2466.0930456
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.35",2463.5025329
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.35",2443.4590609
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.35",2405.3938703
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.4",2499.0621091
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.4",2497.0048048
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.4",2476.9920626
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.4",2439.1647742
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.45",2530.6337693
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.45",2529.3567264
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.45",2509.4115537
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.45",2470.7582273
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","point",NA,2562.0487838
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","point",NA,2560.740829
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","point",NA,2540.4292691
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","point",NA,2502.5949025
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.55",2593.470646
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.55",2592.2700392
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.55",2571.6568004
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.55",2533.8867311
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.6",2626.2996712
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.6",2624.7721564
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.6",2604.8606158
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.6",2566.7826122
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.65",2660.4780684
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.65",2658.355378
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.65",2639.0392651
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.65",2600.4874544
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.7",2696.0099014
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.7",2694.261898
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.7",2674.8389987
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.7",2636.3937184
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.75",2734.9861396
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.75",2734.1317491
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.75",2714.3046295
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.75",2676.7059028
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.8",2777.2691401
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.8",2777.48748
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.8",2758.2807761
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.8",2720.6426893
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.85",2828.2339666
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.85",2829.3086574
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.85",2809.9450155
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.85",2772.6508657
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.9",2893.6055703
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.9",2894.5749695
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.9",2875.5960178
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.9",2838.2489863
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.95",2990.427613
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.95",2992.6363923
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.95",2974.5009533
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.95",2937.3376529
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.975",3075.4064598
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.975",3078.9397959
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.975",3060.1404215
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.975",3026.091842
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.99",3174.1884905
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.99",3180.8563162
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.99",3165.6338513
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.99",3131.0417776
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM","Germany","quantile","0.5",2562.0487838
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM","Germany","quantile","0.5",2560.740829
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM","Germany","quantile","0.5",2540.4292691
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM","Germany","quantile","0.5",2502.5949025
+2020-12-07,"-1 wk ahead cum death",2020-11-28,"GM","Germany","observed",NA,15974
+2020-12-07,"0 wk ahead cum death",2020-12-05,"GM","Germany","observed",NA,18526
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","point",NA,19664.1410278
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","point",NA,20698.3217786
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","point",NA,21731.3102714
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","point",NA,22755.7883024
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.01",19283.876576
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.01",19785.1262398
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.01",20282.8303556
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.01",20770.2918624
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.025",19335.0505212
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.025",19908.4952982
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.025",20476.9044894
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.025",21035.9433996
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.05",19381.6882136
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.05",20019.8958513
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.05",20654.1870794
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.05",21278.6733595
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.1",19437.9258731
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.1",20155.0682423
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.1",20869.2046128
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.1",21573.8146591
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.15",19477.8310526
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.15",20250.8765924
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.15",21020.8767703
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.15",21782.0033424
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.2",19511.1601019
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.2",20330.1979919
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.2",21146.7825909
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.2",21953.9767882
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.25",19540.4609065
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.25",20400.3869158
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.25",21258.1119432
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.25",22106.6421944
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.3",19567.041976
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.3",20464.1169558
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.3",21359.5606314
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.3",22245.6037579
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.35",19591.9798331
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.35",20524.4849226
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.35",21455.4466505
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.35",22377.0814084
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.4",19616.1463992
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.4",20583.0414087
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.4",21548.6584168
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.4",22505.1405224
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.45",19640.371473
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.45",20641.0453918
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.45",21640.4089968
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.45",22630.6449668
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.5",19664.1410278
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.5",20698.3217786
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.5",21731.3102714
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.5",22755.7883024
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.55",19688.7663018
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.55",20757.1833997
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.55",21824.7607013
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.55",22883.5472064
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.6",19713.8832077
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.6",20817.5521255
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.6",21920.7928139
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.6",23015.3112934
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.65",19740.4508422
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.65",20881.1502287
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.65",22021.7915491
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.65",23154.040533
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.7",19769.0307183
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.7",20949.7402083
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.7",22130.538022
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.7",23303.2597761
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.75",19800.090722
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.75",21024.7280394
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.75",22249.4950884
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.75",23466.7887841
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.8",19835.5534426
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.8",21109.6616406
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.8",22384.3072978
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.8",23652.5462847
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.85",19877.4547522
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.85",21210.536709
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.85",22544.8568671
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.85",23873.4289419
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.9",19931.7480101
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.9",21341.0026343
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.9",22752.6390816
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.9",24158.757698
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.95",20014.6491227
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.95",21540.7995789
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.95",23071.2399599
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.95",24596.4560739
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.975",20090.9071782
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.975",21720.3264909
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.975",23356.148458
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.975",24987.1131223
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM","Germany","quantile","0.99",20181.2706289
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM","Germany","quantile","0.99",21938.6889086
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM","Germany","quantile","0.99",23702.8212779
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM","Germany","quantile","0.99",25465.1160934
+2020-12-07,"-1 wk ahead inc death",2020-11-28,"GM13","Free State of Saxony","observed",NA,232
+2020-12-07,"0 wk ahead inc death",2020-12-05,"GM13","Free State of Saxony","observed",NA,366
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.01",328.3516869
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.01",407.6090503
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.01",488.4993128
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.01",559.8000783
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.025",346.2492548
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.025",429.0240165
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.025",512.3942156
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.025",585.2696172
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.05",361.9506632
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.05",447.6849993
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.05",533.9255999
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.05",608.4450815
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.1",380.9612905
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.1",469.9198728
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.1",558.5427874
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.1",635.9023955
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.15",394.2079174
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.15",484.71634
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.15",575.7688911
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.15",654.9139641
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.2",404.8521945
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.2",496.9701151
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.2",589.8829702
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.2",670.095802
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.25",414.2727971
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.25",507.592094
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.25",602.0447482
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.25",683.8886451
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.3",422.8123696
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.3",517.2999857
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.3",613.0098195
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.3",695.9346483
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.35",430.7463712
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.35",526.3768223
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.35",623.3569547
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.35",707.2131698
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.4",438.1952296
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.4",535.1429234
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.4",633.2161957
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.4",718.1754485
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.45",445.6846762
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.45",543.6705877
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.45",642.7325162
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.45",728.9164976
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","point",NA,452.9047408
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","point",NA,552.1354159
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","point",NA,652.2562319
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","point",NA,739.5816728
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.55",460.2409532
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.55",560.7555152
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.55",661.836713
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.55",750.3002716
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.6",467.7984572
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.6",569.6219572
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.6",671.8923141
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.6",761.263615
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.65",475.6984454
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.65",578.8806945
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.65",682.4274501
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.65",772.9816849
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.7",484.3179923
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.7",588.6925048
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.7",693.5228405
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.7",785.2821904
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.75",493.6251142
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.75",599.5157934
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.75",705.373937
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.75",798.6993489
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.8",504.061747
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.8",611.0607079
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.8",718.9380717
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.8",813.7775035
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.85",516.3947773
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.85",625.0102804
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.85",734.9351299
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.85",831.903983
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.9",531.5936041
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.9",643.5520095
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.9",754.8575471
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.9",854.562488
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.95",555.2010056
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.95",670.4113668
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.95",785.4325719
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.95",889.0684061
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.975",576.1887825
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.975",695.4275256
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.975",812.5160289
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.975",919.1921801
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.99",601.7519689
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.99",725.1650777
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.99",844.913273
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.99",953.732606
+2020-12-07,"1 wk ahead inc death",2020-12-12,"GM13","Free State of Saxony","quantile","0.5",452.9047408
+2020-12-07,"2 wk ahead inc death",2020-12-19,"GM13","Free State of Saxony","quantile","0.5",552.1354159
+2020-12-07,"3 wk ahead inc death",2020-12-26,"GM13","Free State of Saxony","quantile","0.5",652.2562319
+2020-12-07,"4 wk ahead inc death",2021-01-02,"GM13","Free State of Saxony","quantile","0.5",739.5816728
+2020-12-07,"-1 wk ahead cum death",2020-11-28,"GM13","Free State of Saxony","observed",NA,867
+2020-12-07,"0 wk ahead cum death",2020-12-05,"GM13","Free State of Saxony","observed",NA,1233
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","point",NA,1603.8636247
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","point",NA,2065.6600957
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","point",NA,2636.5427018
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","point",NA,3325.0943955
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.01",1298.2841856
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.01",1456.4957385
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.01",1674.2211351
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.01",1958.6554683
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.025",1335.6156664
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.025",1530.1871449
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.025",1791.7497956
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.025",2126.9769643
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.05",1370.2172745
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.05",1599.5329261
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.05",1901.7281729
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.05",2284.3303955
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.1",1414.3198
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.1",1687.9024944
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.1",2041.1529771
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.1",2482.0712779
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.15",1446.4393853
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.15",1752.0541176
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.15",2142.2675996
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.15",2625.2159199
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.2",1473.4182271
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.2",1805.8043115
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.2",2226.8399206
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.2",2744.7999456
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.25",1497.5639842
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.25",1853.8088385
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.25",2302.5655911
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.25",2851.8143303
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.3",1519.778206
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.3",1898.2365052
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.3",2372.5832527
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.3",2950.9541918
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.35",1541.2497246
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.35",1940.9458694
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.35",2439.7285433
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.35",3046.1062334
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.4",1562.1948459
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.4",1982.5542943
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.4",2505.3483658
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.4",3138.920718
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.45",1582.8654879
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.45",2023.759225
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.45",2570.3925989
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.45",3231.3319074
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.5",1603.8636247
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.5",2065.6600957
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.5",2636.5427018
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.5",3325.0943955
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.55",1625.2073724
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.55",2108.5166873
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.55",2704.0056273
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.55",3420.8215994
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.6",1647.5790192
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.6",2153.1027968
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.6",2774.2698327
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.6",3520.2867246
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.65",1671.1100773
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.65",2200.2201411
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.65",2848.793848
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.65",3626.0294683
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.7",1696.5898152
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.7",2251.2138225
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.7",2929.4469109
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.7",3740.6137911
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.75",1724.7853622
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.75",2307.8286805
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.75",3018.9786623
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.75",3867.7481723
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.8",1757.0052279
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.8",2372.3555558
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.8",3121.1627118
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.8",4013.412076
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.85",1795.8218449
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.85",2450.0885562
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.85",3243.8864566
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.85",4188.131867
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.9",1846.7724759
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.9",2551.6381615
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.9",3403.6971286
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.9",4416.379708
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.95",1924.3849203
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.95",2708.1566405
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.95",3651.9071153
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.95",4769.2627677
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.975",1996.3069391
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.975",2850.9961297
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.975",3877.0193471
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.975",5089.0502332
+2020-12-07,"1 wk ahead cum death",2020-12-12,"GM13","Free State of Saxony","quantile","0.99",2083.2453642
+2020-12-07,"2 wk ahead cum death",2020-12-19,"GM13","Free State of Saxony","quantile","0.99",3025.2359077
+2020-12-07,"3 wk ahead cum death",2020-12-26,"GM13","Free State of Saxony","quantile","0.99",4148.5638496
+2020-12-07,"4 wk ahead cum death",2021-01-02,"GM13","Free State of Saxony","quantile","0.99",5472.3193487


### PR DESCRIPTION
# using data for Germany until 2020-12-06,
# using data for Saxony until 2020-12-04,