### PR TITLE
fixed bug that crashed PR check + QOL

### DIFF
--- a/code/validation/covid19.py
+++ b/code/validation/covid19.py
@@ -66,11 +66,17 @@ def validate_quantile_csv_file(csv_fp, mode, country):
         else:
             target_names = VALID_TARGET_NAMES_ICU
         
-        fips_codes = FIPS_CODES[country]
+        try:
+            fips_codes = FIPS_CODES[country]
         
             
-        _, error_messages = json_io_dict_from_quantile_csv_file(cdc_csv_fp, target_names, fips_codes, covid19_row_validator,
+            _, error_messages = json_io_dict_from_quantile_csv_file(cdc_csv_fp, target_names, fips_codes, covid19_row_validator,
                                                                     ['forecast_date', 'target_end_date'])    
+        
+        # Country is not in FIPS code dict
+        except KeyError:
+            error_messages = ["ERROR: Forecast country (" + country + ") is currently not supported"]
+        
         
         if error_messages:
             return error_messages

--- a/code/validation/test-formatting.py
+++ b/code/validation/test-formatting.py
@@ -10,9 +10,6 @@ from pathlib import Path
 sys.path.append(str(Path.cwd().joinpath("code", "validation")))
 import covid19
 
-# List of Countries in the repository
-COUNTRIES = ["Germany", "Poland"]
-
 
 # Check for metadata file
 def check_for_metadata(my_path, model=None):
@@ -77,12 +74,9 @@ def check_formatting(my_path, model=None):
             if filepath not in previous_checked:
                 # delete validated file if currrently present
                 df = df[df['file_path'] != filepath]
-                
+
                 # specify country name and forecast target for further tests
-                country = ""
-                for cou in COUNTRIES:
-                    if cou in filepath:
-                        country = cou
+                country = os.path.basename(filepath).split("-")[3]
                         
                 if "-ICU" in filepath:
                     mode = "ICU"


### PR DESCRIPTION
PR check script would crash out if forecasts for unsupported countries where submitted. Added new Error message for this case. 

New countries can be added by changing FIPS_CODES in covid19.py. (COUNTRIES list is not necessary anymore)