### PR TITLE
New predictions as of 16 August 2021

### DIFF
--- a/data-processed/FIAS_FZJ-Epi1Ger/2021-08-16-Germany-FIAS_FZJ-Epi1Ger-case.csv
+++ b/data-processed/FIAS_FZJ-Epi1Ger/2021-08-16-Germany-FIAS_FZJ-Epi1Ger-case.csv
@@ -1,0 +1,3333 @@
+forecast_date,target,target_end_date,location,location_name,type,quantile,value
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM,Germany,observed,NA,18474
+2021-08-16,0 wk ahead inc case,2021-08-14,GM,Germany,observed,NA,28646
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,point,NA,47415
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.010,41527
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.025,42234
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.050,43171
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.100,44026
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.150,44369
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.200,44942
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.250,45377
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.300,45761
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.350,46069
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.400,46545
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.450,47021
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.500,47415
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.550,48009
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.600,48511
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.650,49033
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.700,49412
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.750,49944
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.800,50630
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.850,51752
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.900,53021
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.950,55074
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.975,57650
+2021-08-16,1 wk ahead inc case,2021-08-21,GM,Germany,quantile,0.990,60097
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,point,NA,73289
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.010,59474
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.025,61207
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.050,63113
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.100,64735
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.150,65791
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.200,66862
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.250,68028
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.300,68815
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.350,69934
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.400,71210
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.450,72029
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.500,73289
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.550,74534
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.600,75826
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.650,77291
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.700,78645
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.750,79953
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.800,81954
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.850,84852
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.900,88523
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.950,94225
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.975,101755
+2021-08-16,2 wk ahead inc case,2021-08-28,GM,Germany,quantile,0.990,109648
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,point,NA,112997
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.010,85040
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.025,88415
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.050,91665
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.100,95206
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.150,97581
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.200,99539
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.250,101789
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.300,103247
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.350,105914
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.400,108622
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.450,109997
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.500,112997
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.550,115622
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.600,118413
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.650,121538
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.700,124746
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.750,127412
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.800,132579
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.850,138537
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.900,147328
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.950,160994
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.975,179826
+2021-08-16,3 wk ahead inc case,2021-09-04,GM,Germany,quantile,0.990,199699
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,point,NA,173645
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.010,121239
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.025,127475
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.050,133108
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.100,139546
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.150,144173
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.200,147794
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.250,151817
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.300,154835
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.350,159462
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.400,165296
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.450,167710
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.500,173645
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.550,178574
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.600,183502
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.650,190242
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.700,197082
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.750,202715
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.800,213176
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.850,225447
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.900,244157
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.950,273327
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.975,315373
+2021-08-16,4 wk ahead inc case,2021-09-11,GM,Germany,quantile,0.990,361140
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM,Germany,observed,NA,3787639
+2021-08-16,0 wk ahead cum case,2021-08-14,GM,Germany,observed,NA,3816285
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,point,NA,3867364
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.010,3859363
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.025,3860555
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.050,3861961
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.100,3863040
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.150,3863598
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.200,3864227
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.250,3864873
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.300,3865425
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.350,3865727
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.400,3866178
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.450,3866813
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.500,3867364
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.550,3867910
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.600,3868438
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.650,3869167
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.700,3869577
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.750,3870211
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.800,3871006
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.850,3871955
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.900,3873385
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.950,3875929
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.975,3878551
+2021-08-16,1 wk ahead cum case,2021-08-21,GM,Germany,quantile,0.990,3881214
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,point,NA,3940562
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.010,3919279
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.025,3921639
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.050,3925168
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.100,3928026
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.150,3929260
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.200,3931295
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.250,3932984
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.300,3934218
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.350,3935561
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.400,3937336
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.450,3939155
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.500,3940562
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.550,3942510
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.600,3944524
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.650,3946494
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.700,3947880
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.750,3950175
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.800,3952730
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.850,3956952
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.900,3962018
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.950,3970007
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.975,3980443
+2021-08-16,2 wk ahead cum case,2021-08-28,GM,Germany,quantile,0.990,3990532
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,point,NA,4053607
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.010,4004623
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.025,4010556
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.050,4017311
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.100,4023181
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.150,4026779
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.200,4030630
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.250,4034796
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.300,4037826
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.350,4041677
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.400,4046032
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.450,4049315
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.500,4053607
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.550,4058215
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.600,4062823
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.650,4068063
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.700,4072734
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.750,4077658
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.800,4084917
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.850,4095711
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.900,4109157
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.950,4130619
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.975,4159151
+2021-08-16,3 wk ahead cum case,2021-09-04,GM,Germany,quantile,0.990,4190082
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,point,NA,4227204
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.010,4125841
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.025,4137939
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.050,4150528
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.100,4163116
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.150,4170964
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.200,4177667
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.250,4186659
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.300,4191890
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.350,4201373
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.400,4211019
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.450,4216577
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.500,4227204
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.550,4237013
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.600,4247640
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.650,4258594
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.700,4269875
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.750,4279684
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.800,4298485
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.850,4320720
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.900,4352927
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.950,4403936
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.975,4475217
+2021-08-16,4 wk ahead cum case,2021-09-11,GM,Germany,quantile,0.990,4550422
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM01,Baden-Württemberg State,observed,NA,1861
+2021-08-16,0 wk ahead inc case,2021-08-14,GM01,Baden-Württemberg State,observed,NA,2989
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,point,NA,5636
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.010,4216
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.025,4405
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.050,4589
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.100,4790
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.150,4942
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.200,5071
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.250,5167
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.300,5282
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.350,5376
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.400,5464
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.450,5546
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.500,5636
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.550,5700
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.600,5794
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.650,5869
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.700,5958
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.750,6059
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.800,6176
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.850,6318
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.900,6521
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.950,6865
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.975,7198
+2021-08-16,1 wk ahead inc case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.990,7579
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,point,NA,9654
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.010,5923
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.025,6396
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.050,6836
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.100,7355
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.150,7731
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.200,8076
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.250,8350
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.300,8692
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.350,8943
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.400,9174
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.450,9457
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.500,9654
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.550,9902
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.600,10133
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.650,10370
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.700,10663
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.750,10969
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.800,11334
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.850,11781
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.900,12474
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.950,13558
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.975,14662
+2021-08-16,2 wk ahead inc case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.990,16097
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,point,NA,16560
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.010,8315
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.025,9258
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.050,10130
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.100,11286
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.150,12113
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.200,12905
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.250,13501
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.300,14310
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.350,14862
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.400,15395
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.450,16089
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.500,16560
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.550,17121
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.600,17735
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.650,18393
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.700,19078
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.750,19878
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.800,20777
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.850,21888
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.900,23827
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.950,26718
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.975,29894
+2021-08-16,3 wk ahead inc case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.990,34136
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,point,NA,28399
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.010,11702
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.025,13411
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.050,15042
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.100,17277
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.150,18933
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.200,20537
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.250,21773
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.300,23508
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.350,24692
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.400,25822
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.450,27295
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.500,28399
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.550,29582
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.600,31028
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.650,32501
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.700,34078
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.750,35919
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.800,38049
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.850,40652
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.900,45490
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.950,52852
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.975,61082
+2021-08-16,4 wk ahead inc case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.990,72231
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM01,Baden-Württemberg State,observed,NA,507391
+2021-08-16,0 wk ahead cum case,2021-08-14,GM01,Baden-Württemberg State,observed,NA,510380
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,point,NA,516491
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.010,514907
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.025,515135
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.050,515334
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.100,515561
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.150,515745
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.200,515877
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.250,515977
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.300,516104
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.350,516224
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.400,516312
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.450,516407
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.500,516491
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.550,516572
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.600,516663
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.650,516750
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.700,516855
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.750,516959
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.800,517079
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.850,517239
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.900,517455
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.950,517843
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.975,518179
+2021-08-16,1 wk ahead cum case,2021-08-21,GM01,Baden-Württemberg State,quantile,0.990,518585
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,point,NA,526155
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.010,520853
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.025,521519
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.050,522173
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.100,522913
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.150,523493
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.200,523960
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.250,524338
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.300,524786
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.350,525172
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.400,525512
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.450,525830
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.500,526155
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.550,526454
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.600,526809
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.650,527157
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.700,527523
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.750,527912
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.800,528410
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.850,529015
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.900,529950
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.950,531423
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.975,532848
+2021-08-16,2 wk ahead cum case,2021-08-28,GM01,Baden-Württemberg State,quantile,0.990,534650
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,point,NA,542668
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.010,529163
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.025,530806
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.050,532372
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.100,534216
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.150,535593
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.200,536831
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.250,537804
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.300,539093
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.350,540015
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.400,540861
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.450,541947
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.500,542668
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.550,543628
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.600,544487
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.650,545459
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.700,546546
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.750,547758
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.800,549186
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.850,550942
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.900,553734
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.950,558142
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.975,562741
+2021-08-16,3 wk ahead cum case,2021-09-04,GM01,Baden-Württemberg State,quantile,0.990,568829
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,point,NA,571099
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.010,540784
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.025,544170
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.050,547400
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.100,551486
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.150,554521
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.200,557440
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.250,559658
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.300,562654
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.350,564717
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.400,566663
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.450,569348
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.500,571099
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.550,573239
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.600,575535
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.650,578103
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.700,580672
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.750,583785
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.800,587248
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.850,591607
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.900,599195
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.950,610831
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.975,623517
+2021-08-16,4 wk ahead cum case,2021-09-11,GM01,Baden-Württemberg State,quantile,0.990,641340
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM02,Free State of Bavaria,observed,NA,1938
+2021-08-16,0 wk ahead inc case,2021-08-14,GM02,Free State of Bavaria,observed,NA,3330
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,point,NA,5989
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.010,4652
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.025,4891
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.050,5099
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.100,5286
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.150,5407
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.200,5510
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.250,5612
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.300,5709
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.350,5797
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.400,5891
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.450,5954
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.500,5989
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.550,6040
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.600,6141
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.650,6209
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.700,6272
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.750,6334
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.800,6449
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.850,6624
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.900,6762
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.950,7007
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.975,7241
+2021-08-16,1 wk ahead inc case,2021-08-21,GM02,Free State of Bavaria,quantile,0.990,7571
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,point,NA,10281
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.010,6682
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.025,7261
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.050,7808
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.100,8280
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.150,8641
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.200,8894
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.250,9164
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.300,9416
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.350,9693
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.400,9927
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.450,10126
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.500,10281
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.550,10408
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.600,10676
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.650,10872
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.700,11082
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.750,11322
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.800,11592
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.850,12137
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.900,12582
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.950,13386
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.975,14139
+2021-08-16,2 wk ahead inc case,2021-08-28,GM02,Free State of Bavaria,quantile,0.990,15265
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,point,NA,17603
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.010,9612
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.025,10735
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.050,11946
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.100,12976
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.150,13778
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.200,14387
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.250,14942
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.300,15517
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.350,16159
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.400,16707
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.450,17195
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.500,17603
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.550,17904
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.600,18566
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.650,19007
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.700,19576
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.750,20184
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.800,20886
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.850,22351
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.900,23447
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.950,25607
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.975,27700
+2021-08-16,3 wk ahead inc case,2021-09-04,GM02,Free State of Bavaria,quantile,0.990,30729
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,point,NA,30088
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.010,13769
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.025,15858
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.050,18265
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.100,20336
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.150,21893
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.200,23150
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.250,24424
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.300,25592
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.350,26902
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.400,28088
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.450,29221
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.500,30088
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.550,30867
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.600,32194
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.650,33203
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.700,34637
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.750,35982
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.800,37504
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.850,41167
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.900,43752
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.950,48831
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.975,54141
+2021-08-16,4 wk ahead inc case,2021-09-11,GM02,Free State of Bavaria,quantile,0.990,61769
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM02,Free State of Bavaria,observed,NA,655458
+2021-08-16,0 wk ahead cum case,2021-08-14,GM02,Free State of Bavaria,observed,NA,658788
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,point,NA,665267
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.010,663778
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.025,664032
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.050,664249
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.100,664480
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.150,664609
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.200,664721
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.250,664825
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.300,664938
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.350,665043
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.400,665142
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.450,665197
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.500,665267
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.550,665322
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.600,665410
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.650,665477
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.700,665567
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.750,665630
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.800,665744
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.850,665940
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.900,666092
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.950,666357
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.975,666612
+2021-08-16,1 wk ahead cum case,2021-08-21,GM02,Free State of Bavaria,quantile,0.990,666968
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,point,NA,675509
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.010,670460
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.025,671315
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.050,672071
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.100,672754
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.150,673245
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.200,673599
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.250,673988
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.300,674374
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.350,674731
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.400,675079
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.450,675360
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.500,675509
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.550,675698
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.600,676106
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.650,676371
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.700,676651
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.750,676919
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.800,677363
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.850,678096
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.900,678680
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.950,679704
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.975,680740
+2021-08-16,2 wk ahead cum case,2021-08-28,GM02,Free State of Bavaria,quantile,0.990,682246
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,point,NA,693125
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.010,680031
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.025,682075
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.050,684050
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.100,685690
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.150,687042
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.200,687931
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.250,688968
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.300,689866
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.350,690923
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.400,691812
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.450,692552
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.500,693125
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.550,693599
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.600,694665
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.650,695396
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.700,696186
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.750,697095
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.800,698191
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.850,700333
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.900,702101
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.950,705389
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.975,708322
+2021-08-16,3 wk ahead cum case,2021-09-04,GM02,Free State of Bavaria,quantile,0.990,712963
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,point,NA,723208
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.010,693876
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.025,697956
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.050,702284
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.100,706034
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.150,709038
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.200,711271
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.250,713229
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.300,715406
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.350,717832
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.400,719872
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.450,721719
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.500,723208
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.550,724366
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.600,726902
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.650,728611
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.700,730679
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.750,733050
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.800,735779
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.850,741458
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.900,745730
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.950,754139
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.975,762574
+2021-08-16,4 wk ahead cum case,2021-09-11,GM02,Free State of Bavaria,quantile,0.990,774731
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM03,Free Hanseatic City of Bremen,observed,NA,176
+2021-08-16,0 wk ahead inc case,2021-08-14,GM03,Free Hanseatic City of Bremen,observed,NA,220
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,point,NA,376
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.010,287
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.025,302
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.050,316
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.100,330
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.150,338
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.200,346
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.250,351
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.300,359
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.350,364
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.400,367
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.450,371
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.500,376
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.550,382
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.600,387
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.650,394
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.700,399
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.750,404
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.800,411
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.850,420
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.900,431
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.950,449
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.975,468
+2021-08-16,1 wk ahead inc case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.990,491
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,point,NA,595
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.010,377
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.025,411
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.050,439
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.100,474
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.150,498
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.200,513
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.250,527
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.300,546
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.350,557
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.400,569
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.450,580
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.500,595
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.550,605
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.600,621
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.650,638
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.700,656
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.750,669
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.800,689
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.850,715
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.900,749
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.950,806
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.975,863
+2021-08-16,2 wk ahead inc case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.990,932
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,point,NA,935
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.010,494
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.025,557
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.050,609
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.100,677
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.150,727
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.200,760
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.250,789
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.300,819
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.350,852
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.400,879
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.450,907
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.500,935
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.550,959
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.600,994
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.650,1032
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.700,1080
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.750,1110
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.800,1154
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.850,1217
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.900,1299
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.950,1439
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.975,1600
+2021-08-16,3 wk ahead inc case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.990,1772
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,point,NA,1465
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.010,649
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.025,754
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.050,845
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.100,973
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.150,1061
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.200,1128
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.250,1181
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.300,1239
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.350,1304
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.400,1361
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.450,1412
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.500,1465
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.550,1525
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.600,1593
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.650,1669
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.700,1768
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.750,1833
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.800,1935
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.850,2076
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.900,2254
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.950,2569
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.975,2961
+2021-08-16,4 wk ahead inc case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.990,3390
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM03,Free Hanseatic City of Bremen,observed,NA,28047
+2021-08-16,0 wk ahead cum case,2021-08-14,GM03,Free Hanseatic City of Bremen,observed,NA,28267
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,point,NA,28675
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.010,28572
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.025,28592
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.050,28606
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.100,28622
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.150,28632
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.200,28639
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.250,28647
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.300,28654
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.350,28661
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.400,28665
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.450,28669
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.500,28675
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.550,28679
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.600,28685
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.650,28691
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.700,28698
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.750,28705
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.800,28713
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.850,28721
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.900,28734
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.950,28754
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.975,28775
+2021-08-16,1 wk ahead cum case,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.990,28798
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,point,NA,29270
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.010,28951
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.025,29003
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.050,29047
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.100,29097
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.150,29130
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.200,29152
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.250,29174
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.300,29201
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.350,29217
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.400,29235
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.450,29247
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.500,29270
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.550,29287
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.600,29306
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.650,29333
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.700,29356
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.750,29371
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.800,29399
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.850,29439
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.900,29482
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.950,29557
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.975,29635
+2021-08-16,2 wk ahead cum case,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.990,29725
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,point,NA,30205
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.010,29445
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.025,29559
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.050,29658
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.100,29775
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.150,29864
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.200,29914
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.250,29964
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.300,30024
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.350,30069
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.400,30112
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.450,30152
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.500,30205
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.550,30243
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.600,30306
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.650,30361
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.700,30433
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.750,30477
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.800,30557
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.850,30649
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.900,30783
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.950,31001
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.975,31231
+2021-08-16,3 wk ahead cum case,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.990,31504
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,point,NA,31673
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.010,30095
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.025,30314
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.050,30499
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.100,30747
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.150,30923
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.200,31042
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.250,31146
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.300,31256
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.350,31372
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.400,31470
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.450,31575
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.500,31673
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.550,31764
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.600,31894
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.650,32034
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.700,32204
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.750,32320
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.800,32483
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.850,32723
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.900,33025
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.950,33573
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.975,34196
+2021-08-16,4 wk ahead cum case,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.990,34880
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM04,Free Hanseatic City of Hamburg,observed,NA,856
+2021-08-16,0 wk ahead inc case,2021-08-14,GM04,Free Hanseatic City of Hamburg,observed,NA,1570
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,point,NA,2772
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2130
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2254
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2346
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2435
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2503
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2575
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2620
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2651
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2677
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2707
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2740
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2772
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2799
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2832
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2868
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2897
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2953
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.800,3007
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.850,3068
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.900,3143
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.950,3264
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.975,3383
+2021-08-16,1 wk ahead inc case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.990,3543
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,point,NA,4794
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.010,3087
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.025,3401
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.050,3635
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.100,3872
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.150,4043
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.200,4237
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.250,4365
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.300,4449
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.350,4532
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.400,4637
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.450,4703
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.500,4794
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.550,4893
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.600,4976
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.650,5094
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.700,5223
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.750,5349
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.800,5498
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.850,5688
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.900,5924
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.950,6343
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.975,6727
+2021-08-16,2 wk ahead inc case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.990,7271
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,point,NA,8272
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.010,4472
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.025,5121
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.050,5637
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.100,6121
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.150,6542
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.200,6928
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.250,7251
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.300,7465
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.350,7658
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.400,7908
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.450,8086
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.500,8272
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.550,8525
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.600,8753
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.650,9052
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.700,9371
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.750,9690
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.800,10031
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.850,10561
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.900,11133
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.950,12319
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.975,13396
+2021-08-16,3 wk ahead inc case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.990,14937
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,point,NA,14300
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.010,6464
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.025,7705
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.050,8689
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.100,9693
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.150,10559
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.200,11386
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.250,12036
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.300,12479
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.350,12951
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.400,13513
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.450,13867
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.500,14300
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.550,14792
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.600,15383
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.650,16111
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.700,16800
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.750,17509
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.800,18346
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.850,19655
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.900,20935
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.950,23878
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.975,26694
+2021-08-16,4 wk ahead inc case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.990,30661
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM04,Free Hanseatic City of Hamburg,observed,NA,79815
+2021-08-16,0 wk ahead cum case,2021-08-14,GM04,Free Hanseatic City of Hamburg,observed,NA,81385
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,point,NA,84402
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.010,83693
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.025,83833
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.050,83930
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.100,84034
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.150,84104
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.200,84187
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.250,84234
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.300,84271
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.350,84299
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.400,84329
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.450,84368
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.500,84402
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.550,84435
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.600,84466
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.650,84506
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.700,84551
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.750,84607
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.800,84656
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.850,84726
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.900,84808
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.950,84934
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.975,85069
+2021-08-16,1 wk ahead cum case,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.990,85240
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,point,NA,89185
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.010,86794
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.025,87236
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.050,87569
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.100,87909
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.150,88154
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.200,88438
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.250,88607
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.300,88706
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.350,88820
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.400,88975
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.450,89079
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.500,89185
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.550,89325
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.600,89450
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.650,89608
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.700,89749
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.750,89949
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.800,90154
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.850,90420
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.900,90740
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.950,91282
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.975,91784
+2021-08-16,2 wk ahead cum case,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.990,92518
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,point,NA,97469
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.010,91242
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.025,92360
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.050,93198
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.100,94056
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.150,94686
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.200,95377
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.250,95854
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.300,96174
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.350,96474
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.400,96910
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.450,97149
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.500,97469
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.550,97835
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.600,98190
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.650,98662
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.700,99165
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.750,99653
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.800,100227
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.850,100943
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.900,101882
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.950,103614
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.975,105204
+2021-08-16,3 wk ahead cum case,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.990,107423
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,point,NA,111747
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.010,97735
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.025,100077
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.050,101928
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.100,103733
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.150,105240
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.200,106718
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.250,107912
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.300,108688
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.350,109404
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.400,110374
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.450,111045
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.500,111747
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.550,112731
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.600,113582
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.650,114731
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.700,115985
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.750,117208
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.800,118536
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.850,120581
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.900,122804
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.950,127460
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.975,131877
+2021-08-16,4 wk ahead cum case,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.990,137995
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM05,Hesse State,observed,NA,1324
+2021-08-16,0 wk ahead inc case,2021-08-14,GM05,Hesse State,observed,NA,2009
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,point,NA,3444
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.010,2509
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.025,2644
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.050,2771
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.100,2930
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.150,3026
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.200,3104
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.250,3157
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.300,3211
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.350,3279
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.400,3338
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.450,3380
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.500,3444
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.550,3495
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.600,3543
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.650,3605
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.700,3671
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.750,3724
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.800,3808
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.850,3894
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.900,4016
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.950,4207
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.975,4429
+2021-08-16,1 wk ahead inc case,2021-08-21,GM05,Hesse State,quantile,0.990,4675
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,point,NA,5494
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.010,3240
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.025,3535
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.050,3836
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.100,4207
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.150,4438
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.200,4631
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.250,4752
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.300,4917
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.350,5093
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.400,5244
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.450,5353
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.500,5494
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.550,5650
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.600,5792
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.650,5946
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.700,6119
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.750,6292
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.800,6532
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.850,6776
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.900,7164
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.950,7801
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.975,8461
+2021-08-16,2 wk ahead inc case,2021-08-28,GM05,Hesse State,quantile,0.990,9312
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,point,NA,8769
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.010,4179
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.025,4720
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.050,5294
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.100,6054
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.150,6500
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.200,6894
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.250,7170
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.300,7507
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.350,7872
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.400,8209
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.450,8456
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.500,8769
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.550,9116
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.600,9481
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.650,9795
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.700,10236
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.750,10616
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.800,11214
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.850,11807
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.900,12809
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.950,14475
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.975,16175
+2021-08-16,3 wk ahead inc case,2021-09-04,GM05,Hesse State,quantile,0.990,18548
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,point,NA,14035
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.010,5384
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.025,6305
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.050,7317
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.100,8671
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.150,9526
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.200,10249
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.250,10814
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.300,11445
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.350,12168
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.400,12812
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.450,13351
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.500,14035
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.550,14679
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.600,15468
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.650,16086
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.700,17111
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.750,17887
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.800,19241
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.850,20529
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.900,22882
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.950,26787
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.975,30889
+2021-08-16,4 wk ahead inc case,2021-09-11,GM05,Hesse State,quantile,0.990,36897
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM05,Hesse State,observed,NA,296092
+2021-08-16,0 wk ahead cum case,2021-08-14,GM05,Hesse State,observed,NA,298101
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,point,NA,301845
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.010,300771
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.025,300931
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.050,301082
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.100,301253
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.150,301377
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.200,301450
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.250,301513
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.300,301572
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.350,301641
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.400,301711
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.450,301769
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.500,301845
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.550,301887
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.600,301943
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.650,302006
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.700,302063
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.750,302141
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.800,302225
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.850,302324
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.900,302453
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.950,302671
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.975,302900
+2021-08-16,1 wk ahead cum case,2021-08-21,GM05,Hesse State,quantile,0.990,303162
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,point,NA,307326
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.010,304031
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.025,304480
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.050,304912
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.100,305466
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.150,305810
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.200,306100
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.250,306272
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.300,306480
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.350,306733
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.400,306944
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.450,307110
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.500,307326
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.550,307541
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.600,307722
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.650,307956
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.700,308196
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.750,308435
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.800,308738
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.850,309118
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.900,309608
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.950,310439
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.975,311374
+2021-08-16,2 wk ahead cum case,2021-08-28,GM05,Hesse State,quantile,0.990,312438
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,point,NA,316089
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.010,308223
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.025,309200
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.050,310217
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.100,311505
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.150,312322
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.200,313008
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.250,313437
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.300,314005
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.350,314656
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.400,315175
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.450,315570
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.500,316089
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.550,316657
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.600,317169
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.650,317764
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.700,318415
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.750,319052
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.800,319966
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.850,320908
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.900,322390
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.950,324854
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.975,327506
+2021-08-16,3 wk ahead cum case,2021-09-04,GM05,Hesse State,quantile,0.990,331024
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,point,NA,330101
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.010,313623
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.025,315510
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.050,317557
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.100,320206
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.150,321832
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.200,323217
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.250,324221
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.300,325445
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.350,326810
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.400,328034
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.450,328917
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.500,330101
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.550,331366
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.600,332690
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.650,333834
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.700,335520
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.750,336965
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.800,339153
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.850,341441
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.900,345294
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.950,351717
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.975,358360
+2021-08-16,4 wk ahead cum case,2021-09-11,GM05,Hesse State,quantile,0.990,367994
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM06,Lower Saxony State,observed,NA,1532
+2021-08-16,0 wk ahead inc case,2021-08-14,GM06,Lower Saxony State,observed,NA,1949
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,point,NA,2540
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.010,1971
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.025,2053
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.050,2119
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.100,2187
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.150,2244
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.200,2297
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.250,2346
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.300,2385
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.350,2421
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.400,2462
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.450,2496
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.500,2540
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.550,2579
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.600,2620
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.650,2664
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.700,2718
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.750,2775
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.800,2826
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.850,2891
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.900,2998
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.950,3163
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.975,3317
+2021-08-16,1 wk ahead inc case,2021-08-21,GM06,Lower Saxony State,quantile,0.990,3528
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,point,NA,3144
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.010,2085
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.025,2219
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.050,2333
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.100,2457
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.150,2565
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.200,2648
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.250,2738
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.300,2822
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.350,2910
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.400,2984
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.450,3065
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.500,3144
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.550,3246
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.600,3320
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.650,3438
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.700,3540
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.750,3671
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.800,3797
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.850,3930
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.900,4186
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.950,4587
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.975,4985
+2021-08-16,2 wk ahead inc case,2021-08-28,GM06,Lower Saxony State,quantile,0.990,5536
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,point,NA,3907
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.010,2209
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.025,2394
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.050,2568
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.100,2746
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.150,2930
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.200,3064
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.250,3207
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.300,3367
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.350,3489
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.400,3619
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.450,3766
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.500,3907
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.550,4071
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.600,4205
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.650,4427
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.700,4632
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.750,4872
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.800,5106
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.850,5373
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.900,5861
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.950,6662
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.975,7495
+2021-08-16,3 wk ahead inc case,2021-09-04,GM06,Lower Saxony State,quantile,0.990,8664
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,point,NA,4841
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.010,2341
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.025,2584
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.050,2822
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.100,3087
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.150,3330
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.200,3542
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.250,3772
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.300,3984
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.350,4178
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.400,4390
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.450,4624
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.500,4841
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.550,5106
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.600,5340
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.650,5706
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.700,6060
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.750,6475
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.800,6850
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.850,7323
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.900,8206
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.950,9695
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.975,11267
+2021-08-16,4 wk ahead inc case,2021-09-11,GM06,Lower Saxony State,quantile,0.990,13542
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM06,Lower Saxony State,observed,NA,266520
+2021-08-16,0 wk ahead cum case,2021-08-14,GM06,Lower Saxony State,observed,NA,268469
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,point,NA,271197
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.010,270494
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.025,270600
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.050,270686
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.100,270774
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.150,270847
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.200,270911
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.250,270966
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.300,271021
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.350,271067
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.400,271107
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.450,271149
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.500,271197
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.550,271236
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.600,271280
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.650,271340
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.700,271386
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.750,271453
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.800,271513
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.850,271605
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.900,271717
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.950,271892
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.975,272061
+2021-08-16,1 wk ahead cum case,2021-08-21,GM06,Lower Saxony State,quantile,0.990,272294
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,point,NA,274346
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.010,272596
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.025,272833
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.050,273036
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.100,273242
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.150,273416
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.200,273565
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.250,273714
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.300,273852
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.350,273968
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.400,274087
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.450,274219
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.500,274346
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.550,274468
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.600,274613
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.650,274768
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.700,274943
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.750,275127
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.800,275318
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.850,275532
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.900,275896
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.950,276480
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.975,277030
+2021-08-16,2 wk ahead cum case,2021-08-28,GM06,Lower Saxony State,quantile,0.990,277801
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,point,NA,278244
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.010,274813
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.025,275258
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.050,275624
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.100,275997
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.150,276349
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.200,276619
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.250,276924
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.300,277197
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.350,277468
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.400,277711
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.450,277967
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.500,278244
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.550,278552
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.600,278816
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.650,279202
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.700,279558
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.750,279986
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.800,280420
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.850,280885
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.900,281734
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.950,283130
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.975,284532
+2021-08-16,3 wk ahead cum case,2021-09-04,GM06,Lower Saxony State,quantile,0.990,286499
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,point,NA,283067
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.010,277181
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.025,277847
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.050,278443
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.100,279086
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.150,279705
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.200,280175
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.250,280646
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.300,281202
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.350,281641
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.400,282096
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.450,282605
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.500,283067
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.550,283671
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.600,284149
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.650,284917
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.700,285568
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.750,286461
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.800,287300
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.850,288193
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.900,289926
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.950,292779
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.975,295812
+2021-08-16,4 wk ahead cum case,2021-09-11,GM06,Lower Saxony State,quantile,0.990,300029
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM07,North Rhine-Westphalia State,observed,NA,5839
+2021-08-16,0 wk ahead inc case,2021-08-14,GM07,North Rhine-Westphalia State,observed,NA,9560
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,point,NA,16836
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.010,14207
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.025,14490
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.050,14776
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.100,15146
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.150,15322
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.200,15544
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.250,15771
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.300,16007
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.350,16192
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.400,16343
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.450,16583
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.500,16836
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.550,16984
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.600,17124
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.650,17353
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.700,17556
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.750,17813
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.800,18145
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.850,18502
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.900,18893
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.950,19617
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.975,20416
+2021-08-16,1 wk ahead inc case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.990,21431
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,point,NA,27775
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.010,21080
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.025,21810
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.050,22320
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.100,23234
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.150,23811
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.200,24308
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.250,24891
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.300,25455
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.350,25915
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.400,26418
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.450,27050
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.500,27775
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.550,28149
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.600,28658
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.650,29216
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.700,29898
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.750,30591
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.800,31536
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.850,32702
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.900,33904
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.950,35978
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.975,38635
+2021-08-16,2 wk ahead inc case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.990,42053
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,point,NA,45855
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.010,31229
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.025,32711
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.050,33594
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.100,35605
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.150,36716
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.200,37951
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.250,39239
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.300,40386
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.350,41674
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.400,42750
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.450,44073
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.500,45855
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.550,46667
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.600,47990
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.650,49172
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.700,50778
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.750,52613
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.800,54606
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.850,57500
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.900,60676
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.950,65969
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.975,72885
+2021-08-16,3 wk ahead inc case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.990,82112
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,point,NA,75499
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.010,46251
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.025,48842
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.050,50678
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.100,54493
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.150,56801
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.200,59156
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.250,61652
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.300,64242
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.350,66691
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.400,68999
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.450,71919
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.500,75499
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.550,77382
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.600,80161
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.650,82563
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.700,86095
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.750,90287
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.800,94855
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.850,101732
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.900,108231
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.950,120853
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.975,137572
+2021-08-16,4 wk ahead inc case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.990,159943
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM07,North Rhine-Westphalia State,observed,NA,832720
+2021-08-16,0 wk ahead cum case,2021-08-14,GM07,North Rhine-Westphalia State,observed,NA,842280
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,point,NA,860332
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.010,857265
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.025,857666
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.050,858040
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.100,858398
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.150,858634
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.200,858914
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.250,859188
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.300,859426
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.350,859653
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.400,859836
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.450,860079
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.500,860332
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.550,860504
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.600,860685
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.650,860905
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.700,861121
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.750,861407
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.800,861771
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.850,862154
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.900,862623
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.950,863382
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.975,864279
+2021-08-16,1 wk ahead cum case,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.990,865320
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,point,NA,888160
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.010,878346
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.025,879353
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.050,880394
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.100,881672
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.150,882417
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.200,883245
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.250,884121
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.300,884948
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.350,885612
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.400,886276
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.450,887201
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.500,888160
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.550,888790
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.600,889315
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.650,890175
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.700,890994
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.750,891993
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.800,893312
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.850,894779
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.900,896466
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.950,899317
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.975,902889
+2021-08-16,2 wk ahead cum case,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.990,907361
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,point,NA,933944
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.010,909685
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.025,912191
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.050,914129
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.100,917281
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.150,919373
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.200,921234
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.250,923300
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.300,925341
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.350,927046
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.400,928906
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.450,931180
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.500,933944
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.550,935339
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.600,937225
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.650,939318
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.700,941876
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.750,944511
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.800,948128
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.850,952520
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.900,957273
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.950,965334
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.975,975848
+2021-08-16,3 wk ahead cum case,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.990,989593
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,point,NA,1009397
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.010,955866
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.025,961335
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.050,964544
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.100,971838
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.150,976068
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.200,980516
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.250,985257
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.300,989341
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.350,993936
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.400,998020
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.450,1003125
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.500,1009397
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.550,1012461
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.600,1017639
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.650,1021942
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.700,1027995
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.750,1034923
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.800,1042581
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.850,1053448
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.900,1065482
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.950,1086049
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.975,1112960
+2021-08-16,4 wk ahead cum case,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.990,1149280
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM08,Rhineland-Palatinate State,observed,NA,884
+2021-08-16,0 wk ahead inc case,2021-08-14,GM08,Rhineland-Palatinate State,observed,NA,1188
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,point,NA,1809
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.010,1269
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.025,1350
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.050,1426
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.100,1502
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.150,1558
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.200,1608
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.250,1643
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.300,1683
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.350,1716
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.400,1753
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.450,1784
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.500,1809
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.550,1840
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.600,1873
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.650,1915
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.700,1950
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.750,1988
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.800,2031
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.850,2081
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.900,2147
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.950,2254
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.975,2364
+2021-08-16,1 wk ahead inc case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.990,2514
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,point,NA,2676
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.010,1479
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.025,1640
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.050,1789
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.100,1961
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.150,2080
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.200,2194
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.250,2272
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.300,2364
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.350,2447
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.400,2530
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.450,2602
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.500,2676
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.550,2747
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.600,2828
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.650,2929
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.700,3028
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.750,3130
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.800,3246
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.850,3373
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.900,3564
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.950,3863
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.975,4187
+2021-08-16,2 wk ahead inc case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.990,4642
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,point,NA,3932
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.010,1721
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.025,1980
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.050,2247
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.100,2554
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.150,2783
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.200,2989
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.250,3142
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.300,3321
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.350,3490
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.400,3651
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.450,3784
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.500,3932
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.550,4088
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.600,4252
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.650,4478
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.700,4695
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.750,4939
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.800,5188
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.850,5472
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.900,5885
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.950,6609
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.975,7447
+2021-08-16,3 wk ahead inc case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.990,8607
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,point,NA,5785
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.010,2010
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.025,2395
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.050,2813
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.100,3317
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.150,3715
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.200,4060
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.250,4346
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.300,4651
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.350,4963
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.400,5274
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.450,5507
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.500,5785
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.550,6084
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.600,6429
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.650,6834
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.700,7252
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.750,7789
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.800,8273
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.850,8877
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.900,9713
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.950,11312
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.975,13130
+2021-08-16,4 wk ahead inc case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.990,15970
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM08,Rhineland-Palatinate State,observed,NA,158351
+2021-08-16,0 wk ahead cum case,2021-08-14,GM08,Rhineland-Palatinate State,observed,NA,159539
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,point,NA,161425
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.010,160802
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.025,160904
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.050,160990
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.100,161078
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.150,161143
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.200,161200
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.250,161234
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.300,161283
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.350,161326
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.400,161363
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.450,161398
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.500,161425
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.550,161459
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.600,161507
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.650,161545
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.700,161584
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.750,161622
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.800,161672
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.850,161727
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.900,161797
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.950,161912
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.975,162033
+2021-08-16,1 wk ahead cum case,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.990,162202
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,point,NA,164094
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.010,162290
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.025,162547
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.050,162785
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.100,163037
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.150,163223
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.200,163394
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.250,163510
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.300,163654
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.350,163772
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.400,163894
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.450,164002
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.500,164094
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.550,164210
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.600,164329
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.650,164478
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.700,164613
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.750,164752
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.800,164911
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.850,165103
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.900,165357
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.950,165777
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.975,166217
+2021-08-16,2 wk ahead cum case,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.990,166826
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,point,NA,168053
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.010,164016
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.025,164540
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.050,165038
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.100,165599
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.150,165999
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.200,166391
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.250,166666
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.300,166968
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.350,167258
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.400,167552
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.450,167786
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.500,168053
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.550,168310
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.600,168589
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.650,168954
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.700,169309
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.750,169678
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.800,170115
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.850,170568
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.900,171231
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.950,172377
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.975,173632
+2021-08-16,3 wk ahead cum case,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.990,175430
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,point,NA,173838
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.010,166025
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.025,166940
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.050,167845
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.100,168938
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.150,169697
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.200,170457
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.250,170987
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.300,171622
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.350,172215
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.400,172808
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.450,173287
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.500,173838
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.550,174390
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.600,174993
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.650,175784
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.700,176585
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.750,177459
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.800,178395
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.850,179446
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.900,180934
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.950,183701
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.975,186854
+2021-08-16,4 wk ahead cum case,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.990,191359
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM09,Saarland State,observed,NA,320
+2021-08-16,0 wk ahead inc case,2021-08-14,GM09,Saarland State,observed,NA,359
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,point,NA,641
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.010,544
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.025,558
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.050,574
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.100,589
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.150,599
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.200,606
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.250,611
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.300,620
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.350,624
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.400,631
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.450,635
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.500,641
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.550,646
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.600,652
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.650,659
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.700,668
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.750,678
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.800,691
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.850,704
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.900,722
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.950,761
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.975,800
+2021-08-16,1 wk ahead inc case,2021-08-21,GM09,Saarland State,quantile,0.990,853
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,point,NA,939
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.010,739
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.025,769
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.050,797
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.100,829
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.150,850
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.200,865
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.250,876
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.300,892
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.350,900
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.400,916
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.450,926
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.500,939
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.550,951
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.600,966
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.650,983
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.700,1006
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.750,1031
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.800,1062
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.850,1098
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.900,1144
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.950,1247
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.975,1361
+2021-08-16,2 wk ahead inc case,2021-08-28,GM09,Saarland State,quantile,0.990,1521
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,point,NA,1377
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.010,1007
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.025,1060
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.050,1112
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.100,1164
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.150,1207
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.200,1230
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.250,1254
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.300,1282
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.350,1297
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.400,1333
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.450,1349
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.500,1377
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.550,1404
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.600,1432
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.650,1471
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.700,1519
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.750,1569
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.800,1633
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.850,1710
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.900,1816
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.950,2060
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.975,2323
+2021-08-16,3 wk ahead inc case,2021-09-04,GM09,Saarland State,quantile,0.990,2725
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,point,NA,2015
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.010,1369
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.025,1461
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.050,1551
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.100,1639
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.150,1713
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.200,1750
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.250,1792
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.300,1845
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.350,1870
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.400,1935
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.450,1970
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.500,2015
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.550,2069
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.600,2121
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.650,2193
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.700,2287
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.750,2392
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.800,2518
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.850,2669
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.900,2891
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.950,3392
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.975,3967
+2021-08-16,4 wk ahead inc case,2021-09-11,GM09,Saarland State,quantile,0.990,4875
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM09,Saarland State,observed,NA,42407
+2021-08-16,0 wk ahead cum case,2021-08-14,GM09,Saarland State,observed,NA,42766
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,point,NA,43474
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.010,43334
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.025,43354
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.050,43375
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.100,43400
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.150,43416
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.200,43425
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.250,43434
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.300,43446
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.350,43451
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.400,43457
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.450,43465
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.500,43474
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.550,43480
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.600,43485
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.650,43493
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.700,43504
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.750,43516
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.800,43531
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.850,43548
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.900,43570
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.950,43612
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.975,43654
+2021-08-16,1 wk ahead cum case,2021-08-21,GM09,Saarland State,quantile,0.990,43710
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,point,NA,44412
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.010,44074
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.025,44121
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.050,44179
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.100,44229
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.150,44266
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.200,44289
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.250,44310
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.300,44338
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.350,44349
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.400,44378
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.450,44395
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.500,44412
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.550,44430
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.600,44451
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.650,44477
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.700,44509
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.750,44546
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.800,44592
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.850,44647
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.900,44711
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.950,44860
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.975,45015
+2021-08-16,2 wk ahead cum case,2021-08-28,GM09,Saarland State,quantile,0.990,45227
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,point,NA,45793
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.010,45077
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.025,45185
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.050,45282
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.100,45397
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.150,45472
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.200,45526
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.250,45565
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.300,45623
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.350,45651
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.400,45708
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.450,45743
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.500,45793
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.550,45829
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.600,45883
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.650,45945
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.700,46032
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.750,46113
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.800,46226
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.850,46356
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.900,46530
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.950,46902
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.975,47328
+2021-08-16,3 wk ahead cum case,2021-09-04,GM09,Saarland State,quantile,0.990,47939
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,point,NA,47814
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.010,46456
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.025,46644
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.050,46832
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.100,47033
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.150,47188
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.200,47283
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.250,47359
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.300,47474
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.350,47524
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.400,47642
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.450,47705
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.500,47814
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.550,47903
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.600,48005
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.650,48140
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.700,48318
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.750,48492
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.800,48736
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.850,49010
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.900,49395
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.950,50298
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.975,51293
+2021-08-16,4 wk ahead cum case,2021-09-11,GM09,Saarland State,quantile,0.990,52822
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM10,Schleswig-Holstein State,observed,NA,1114
+2021-08-16,0 wk ahead inc case,2021-08-14,GM10,Schleswig-Holstein State,observed,NA,1406
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,point,NA,2248
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.010,1977
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.025,2040
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.050,2069
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.100,2121
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.150,2140
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.200,2166
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.250,2173
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.300,2185
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.350,2202
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.400,2220
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.450,2237
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.500,2248
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.550,2263
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.600,2278
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.650,2304
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.700,2324
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.750,2339
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.800,2370
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.850,2409
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.900,2454
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.950,2541
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.975,2633
+2021-08-16,1 wk ahead inc case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.990,2758
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,point,NA,3217
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.010,2665
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.025,2788
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.050,2846
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.100,2940
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.150,2997
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.200,3034
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.250,3054
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.300,3082
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.350,3114
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.400,3154
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.450,3188
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.500,3217
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.550,3251
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.600,3273
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.650,3337
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.700,3388
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.750,3427
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.800,3491
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.850,3585
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.900,3694
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.950,3917
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.975,4162
+2021-08-16,2 wk ahead inc case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.990,4494
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,point,NA,4594
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.010,3602
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.025,3803
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.050,3949
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.100,4078
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.150,4200
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.200,4259
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.250,4280
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.300,4340
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.350,4400
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.400,4475
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.450,4542
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.500,4594
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.550,4664
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.600,4720
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.650,4820
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.700,4930
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.750,5018
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.800,5127
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.850,5322
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.900,5594
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.950,6053
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.975,6597
+2021-08-16,3 wk ahead inc case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.990,7374
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,point,NA,6567
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.010,4863
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.025,5185
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.050,5436
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.100,5668
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.150,5856
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.200,5972
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.250,6006
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.300,6133
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.350,6223
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.400,6369
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.450,6470
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.500,6567
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.550,6687
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.600,6811
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.650,6987
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.700,7174
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.750,7339
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.800,7571
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.850,7934
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.900,8444
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.950,9342
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.975,10451
+2021-08-16,4 wk ahead inc case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.990,12043
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM10,Schleswig-Holstein State,observed,NA,66472
+2021-08-16,0 wk ahead cum case,2021-08-14,GM10,Schleswig-Holstein State,observed,NA,67878
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,point,NA,70320
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.010,69922
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.025,70014
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.050,70061
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.100,70124
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.150,70169
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.200,70196
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.250,70224
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.300,70233
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.350,70262
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.400,70276
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.450,70299
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.500,70320
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.550,70337
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.600,70362
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.650,70383
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.700,70407
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.750,70443
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.800,70478
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.850,70519
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.900,70576
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.950,70676
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.975,70772
+2021-08-16,1 wk ahead cum case,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.990,70916
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,point,NA,73528
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.010,72595
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.025,72810
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.050,72911
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.100,73087
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.150,73158
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.200,73244
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.250,73273
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.300,73316
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.350,73366
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.400,73428
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.450,73489
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.500,73528
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.550,73591
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.600,73635
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.650,73724
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.700,73805
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.750,73860
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.800,73959
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.850,74100
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.900,74275
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.950,74585
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.975,74928
+2021-08-16,2 wk ahead cum case,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.990,75402
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,point,NA,78135
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.010,76198
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.025,76609
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.050,76823
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.100,77164
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.150,77360
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.200,77492
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.250,77575
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.300,77681
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.350,77784
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.400,77911
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.450,78047
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.500,78135
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.550,78249
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.600,78345
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.650,78577
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.700,78740
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.750,78853
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.800,79101
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.850,79442
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.900,79822
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.950,80615
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.975,81506
+2021-08-16,3 wk ahead cum case,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.990,82736
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,point,NA,84709
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.010,81039
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.025,81817
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.050,82292
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.100,82811
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.150,83254
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.200,83482
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.250,83564
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.300,83747
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.350,84000
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.400,84292
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.450,84500
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.500,84709
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.550,84956
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.600,85133
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.650,85551
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.700,85918
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.750,86228
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.800,86639
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.850,87348
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.900,88285
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.950,89981
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.975,91987
+2021-08-16,4 wk ahead cum case,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.990,94803
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM11,Brandenburg State,observed,NA,310
+2021-08-16,0 wk ahead inc case,2021-08-14,GM11,Brandenburg State,observed,NA,502
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,point,NA,731
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.010,496
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.025,536
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.050,566
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.100,603
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.150,627
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.200,648
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.250,663
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.300,678
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.350,691
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.400,705
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.450,716
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.500,731
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.550,743
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.600,754
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.650,768
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.700,783
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.750,799
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.800,815
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.850,840
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.900,874
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.950,918
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.975,964
+2021-08-16,1 wk ahead inc case,2021-08-21,GM11,Brandenburg State,quantile,0.990,1028
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,point,NA,1043
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.010,549
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.025,624
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.050,686
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.100,760
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.150,809
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.200,853
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.250,889
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.300,924
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.350,956
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.400,984
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.450,1013
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.500,1043
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.550,1079
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.600,1111
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.650,1143
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.700,1179
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.750,1220
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.800,1261
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.850,1328
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.900,1414
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.950,1545
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.975,1670
+2021-08-16,2 wk ahead inc case,2021-08-28,GM11,Brandenburg State,quantile,0.990,1877
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,point,NA,1500
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.010,609
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.025,729
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.050,829
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.100,954
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.150,1047
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.200,1122
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.250,1190
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.300,1257
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.350,1317
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.400,1369
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.450,1430
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.500,1500
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.550,1567
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.600,1630
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.650,1699
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.700,1773
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.750,1867
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.800,1958
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.850,2102
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.900,2291
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.950,2597
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.975,2894
+2021-08-16,3 wk ahead inc case,2021-09-04,GM11,Brandenburg State,quantile,0.990,3424
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,point,NA,2144
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.010,673
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.025,851
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.050,1002
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.100,1195
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.150,1355
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.200,1476
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.250,1594
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.300,1708
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.350,1810
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.400,1903
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.450,2021
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.500,2144
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.550,2284
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.600,2393
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.650,2521
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.700,2665
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.750,2850
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.800,3036
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.850,3322
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.900,3723
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.950,4364
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.975,5033
+2021-08-16,4 wk ahead inc case,2021-09-11,GM11,Brandenburg State,quantile,0.990,6270
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM11,Brandenburg State,observed,NA,109543
+2021-08-16,0 wk ahead cum case,2021-08-14,GM11,Brandenburg State,observed,NA,110045
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,point,NA,110818
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.010,110548
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.025,110591
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.050,110629
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.100,110672
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.150,110702
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.200,110726
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.250,110741
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.300,110759
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.350,110773
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.400,110789
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.450,110804
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.500,110818
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.550,110831
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.600,110844
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.650,110859
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.700,110877
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.750,110891
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.800,110913
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.850,110941
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.900,110978
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.950,111025
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.975,111075
+2021-08-16,1 wk ahead cum case,2021-08-21,GM11,Brandenburg State,quantile,0.990,111145
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,point,NA,111859
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.010,111101
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.025,111222
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.050,111317
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.100,111434
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.150,111513
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.200,111581
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.250,111635
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.300,111678
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.350,111730
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.400,111771
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.450,111811
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.500,111859
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.550,111915
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.600,111951
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.650,112004
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.700,112057
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.750,112110
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.800,112168
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.850,112264
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.900,112396
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.950,112565
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.975,112751
+2021-08-16,2 wk ahead cum case,2021-08-28,GM11,Brandenburg State,quantile,0.990,113016
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,point,NA,113353
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.010,111710
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.025,111945
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.050,112150
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.100,112384
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.150,112558
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.200,112703
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.250,112827
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.300,112936
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.350,113049
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.400,113144
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.450,113246
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.500,113353
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.550,113478
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.600,113586
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.650,113697
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.700,113831
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.750,113976
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.800,114124
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.850,114365
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.900,114685
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.950,115168
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.975,115646
+2021-08-16,3 wk ahead cum case,2021-09-04,GM11,Brandenburg State,quantile,0.990,116433
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,point,NA,115508
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.010,112385
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.025,112793
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.050,113153
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.100,113583
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.150,113905
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.200,114179
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.250,114418
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.300,114650
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.350,114864
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.400,115051
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.450,115253
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.500,115508
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.550,115747
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.600,115976
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.650,116219
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.700,116492
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.750,116826
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.800,117159
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.850,117691
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.900,118394
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.950,119525
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.975,120656
+2021-08-16,4 wk ahead cum case,2021-09-11,GM11,Brandenburg State,quantile,0.990,122700
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM12,Mecklenburg-Western Pomerania State,observed,NA,267
+2021-08-16,0 wk ahead inc case,2021-08-14,GM12,Mecklenburg-Western Pomerania State,observed,NA,350
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,point,NA,907
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,738
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,770
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,791
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,812
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,833
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,852
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,860
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,868
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,880
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,889
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,900
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,907
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,922
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,932
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,945
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,961
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,979
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1001
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1026
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1059
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1122
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1187
+2021-08-16,1 wk ahead inc case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1281
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,point,NA,1837
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1363
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1437
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1499
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1558
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1621
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1664
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1684
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1712
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1740
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1771
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1800
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1837
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1868
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1906
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1950
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,2004
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,2065
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,2136
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,2225
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,2353
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,2602
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,2879
+2021-08-16,2 wk ahead inc case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,3292
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,point,NA,3704
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,2526
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,2679
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,2822
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,2975
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,3146
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,3240
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,3296
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,3366
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,3439
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,3537
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,3607
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,3704
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,3792
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,3900
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,4022
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,4182
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,4367
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,4562
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,4834
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,5239
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,6051
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,6986
+2021-08-16,3 wk ahead inc case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,8500
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,point,NA,7427
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,4663
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,5021
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,5307
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,5694
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,6095
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,6296
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,6439
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,6625
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,6811
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,7026
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,7270
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,7427
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,7714
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,7957
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,8272
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,8745
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,9203
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,9733
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,10478
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,11638
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,14116
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,16952
+2021-08-16,4 wk ahead inc case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,21951
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM12,Mecklenburg-Western Pomerania State,observed,NA,44705
+2021-08-16,0 wk ahead cum case,2021-08-14,GM12,Mecklenburg-Western Pomerania State,observed,NA,45055
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,point,NA,46017
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,45790
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,45831
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,45867
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,45892
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,45916
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,45938
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,45958
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,45966
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,45979
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,45994
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,46006
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,46017
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,46030
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,46044
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,46059
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,46075
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,46101
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,46125
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,46153
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,46190
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,46257
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,46326
+2021-08-16,1 wk ahead cum case,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,46423
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,point,NA,47851
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,47151
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,47276
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,47367
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,47452
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,47543
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,47612
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,47644
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,47677
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,47726
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,47761
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,47805
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,47851
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,47905
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,47945
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,48000
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,48080
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,48167
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,48254
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,48379
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,48535
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,48854
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,49199
+2021-08-16,2 wk ahead cum case,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,49708
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,point,NA,51570
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,49670
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,49953
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,50205
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,50429
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,50681
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,50851
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,50941
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,51045
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,51179
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,51292
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,51408
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,51570
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,51682
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,51849
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,52037
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,52266
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,52527
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,52814
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,53205
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,53771
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,54898
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,56183
+2021-08-16,3 wk ahead cum case,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,58195
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,point,NA,59017
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,54351
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,54953
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,55517
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,56119
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,56797
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,57154
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,57380
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,57681
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,57963
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,58358
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,58640
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,59017
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,59393
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,59807
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,60315
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,60992
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,61745
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,62554
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,63683
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,65395
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,68970
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,73128
+2021-08-16,4 wk ahead cum case,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,80145
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM13,Free State of Saxony,observed,NA,308
+2021-08-16,0 wk ahead inc case,2021-08-14,GM13,Free State of Saxony,observed,NA,536
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,point,NA,690
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.010,522
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.025,542
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.050,558
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.100,580
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.150,596
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.200,612
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.250,624
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.300,639
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.350,653
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.400,666
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.450,679
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.500,690
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.550,705
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.600,720
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.650,733
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.700,749
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.750,770
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.800,792
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.850,820
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.900,855
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.950,912
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.975,973
+2021-08-16,1 wk ahead inc case,2021-08-21,GM13,Free State of Saxony,quantile,0.990,1053
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,point,NA,983
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.010,632
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.025,665
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.050,698
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.100,738
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.150,773
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.200,802
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.250,833
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.300,864
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.350,894
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.400,925
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.450,956
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.500,983
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.550,1018
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.600,1049
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.650,1086
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.700,1129
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.750,1179
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.800,1242
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.850,1308
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.900,1410
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.950,1576
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.975,1758
+2021-08-16,2 wk ahead inc case,2021-08-28,GM13,Free State of Saxony,quantile,0.990,2010
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,point,NA,1396
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.010,764
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.025,813
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.050,871
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.100,935
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.150,999
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.200,1049
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.250,1109
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.300,1167
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.350,1225
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.400,1288
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.450,1347
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.500,1396
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.550,1463
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.600,1533
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.650,1609
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.700,1704
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.750,1816
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.800,1946
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.850,2093
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.900,2325
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.950,2726
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.975,3171
+2021-08-16,3 wk ahead inc case,2021-09-04,GM13,Free State of Saxony,quantile,0.990,3839
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,point,NA,1981
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.010,921
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.025,998
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.050,1087
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.100,1188
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.150,1292
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.200,1373
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.250,1478
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.300,1575
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.350,1675
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.400,1784
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.450,1892
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.500,1981
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.550,2105
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.600,2232
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.650,2376
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.700,2577
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.750,2778
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.800,3045
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.850,3351
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.900,3827
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.950,4697
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.975,5719
+2021-08-16,4 wk ahead inc case,2021-09-11,GM13,Free State of Saxony,quantile,0.990,7336
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM13,Free State of Saxony,observed,NA,286946
+2021-08-16,0 wk ahead cum case,2021-08-14,GM13,Free State of Saxony,observed,NA,287482
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,point,NA,288168
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.010,287949
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.025,287977
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.050,288004
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.100,288033
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.150,288056
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.200,288073
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.250,288092
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.300,288108
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.350,288123
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.400,288138
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.450,288156
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.500,288168
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.550,288182
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.600,288201
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.650,288216
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.700,288235
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.750,288256
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.800,288283
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.850,288312
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.900,288352
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.950,288416
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.975,288480
+2021-08-16,1 wk ahead cum case,2021-08-21,GM13,Free State of Saxony,quantile,0.990,288567
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,point,NA,289150
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.010,288586
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.025,288648
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.050,288704
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.100,288775
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.150,288831
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.200,288880
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.250,288923
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.300,288972
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.350,289021
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.400,289065
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.450,289108
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.500,289150
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.550,289200
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.600,289253
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.650,289301
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.700,289359
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.750,289437
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.800,289519
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.850,289619
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.900,289758
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.950,289986
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.975,290237
+2021-08-16,2 wk ahead cum case,2021-08-28,GM13,Free State of Saxony,quantile,0.990,290575
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,point,NA,290550
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.010,289351
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.025,289467
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.050,289572
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.100,289714
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.150,289836
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.200,289933
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.250,290036
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.300,290139
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.350,290243
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.400,290352
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.450,290453
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.500,290550
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.550,290672
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.600,290777
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.650,290909
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.700,291062
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.750,291244
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.800,291467
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.850,291706
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.900,292078
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.950,292709
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.975,293405
+2021-08-16,3 wk ahead cum case,2021-09-04,GM13,Free State of Saxony,quantile,0.990,294410
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,point,NA,292529
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.010,290269
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.025,290466
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.050,290664
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.100,290902
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.150,291129
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.200,291303
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.250,291512
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.300,291721
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.350,291913
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.400,292151
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.450,292349
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.500,292529
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.550,292767
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.600,293028
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.650,293290
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.700,293632
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.750,294027
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.800,294510
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.850,295056
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.900,295915
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.950,297420
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.975,299110
+2021-08-16,4 wk ahead cum case,2021-09-11,GM13,Free State of Saxony,quantile,0.990,301742
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM14,Sachsen-Anhalt State,observed,NA,167
+2021-08-16,0 wk ahead inc case,2021-08-14,GM14,Sachsen-Anhalt State,observed,NA,224
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,point,NA,318
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.010,241
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.025,254
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.050,265
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.100,279
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.150,288
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.200,294
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.250,299
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.300,303
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.350,306
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.400,311
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.450,314
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.500,318
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.550,321
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.600,326
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.650,332
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.700,336
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.750,341
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.800,345
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.850,353
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.900,365
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.950,383
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.975,397
+2021-08-16,1 wk ahead inc case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.990,414
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,point,NA,442
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.010,279
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.025,304
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.050,325
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.100,354
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.150,374
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.200,388
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.250,398
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.300,407
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.350,415
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.400,424
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.450,433
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.500,442
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.550,449
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.600,460
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.650,473
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.700,483
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.750,494
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.800,507
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.850,526
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.900,554
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.950,600
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.975,640
+2021-08-16,2 wk ahead inc case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.990,688
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,point,NA,612
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.010,322
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.025,362
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.050,399
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.100,449
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.150,486
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.200,511
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.250,528
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.300,546
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.350,562
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.400,577
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.450,593
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.500,612
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.550,626
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.600,648
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.650,675
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.700,695
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.750,715
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.800,745
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.850,782
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.900,837
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.950,941
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.975,1031
+2021-08-16,3 wk ahead inc case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.990,1141
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,point,NA,848
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.010,371
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.025,431
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.050,491
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.100,569
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.150,631
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.200,672
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.250,705
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.300,733
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.350,759
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.400,785
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.450,816
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.500,848
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.550,870
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.600,916
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.650,960
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.700,999
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.750,1039
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.800,1092
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.850,1164
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.900,1267
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.950,1474
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.975,1667
+2021-08-16,4 wk ahead inc case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.990,1894
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM14,Sachsen-Anhalt State,observed,NA,99692
+2021-08-16,0 wk ahead cum case,2021-08-14,GM14,Sachsen-Anhalt State,observed,NA,99916
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,point,NA,100255
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.010,100167
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.025,100182
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.050,100195
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.100,100210
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.150,100221
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.200,100227
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.250,100233
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.300,100238
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.350,100241
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.400,100248
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.450,100252
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.500,100255
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.550,100259
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.600,100263
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.650,100269
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.700,100273
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.750,100280
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.800,100287
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.850,100295
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.900,100308
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.950,100327
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.975,100342
+2021-08-16,1 wk ahead cum case,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.990,100362
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,point,NA,100697
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.010,100446
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.025,100487
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.050,100520
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.100,100565
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.150,100594
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.200,100615
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.250,100632
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.300,100645
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.350,100656
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.400,100671
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.450,100682
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.500,100697
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.550,100707
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.600,100723
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.650,100742
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.700,100758
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.750,100775
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.800,100792
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.850,100821
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.900,100859
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.950,100928
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.975,100980
+2021-08-16,2 wk ahead cum case,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.990,101048
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,point,NA,101309
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.010,100769
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.025,100850
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.050,100919
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.100,101016
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.150,101080
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.200,101126
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.250,101162
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.300,101193
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.350,101217
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.400,101248
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.450,101277
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.500,101309
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.550,101333
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.600,101372
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.650,101419
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.700,101454
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.750,101489
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.800,101536
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.850,101603
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.900,101702
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.950,101867
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.975,102013
+2021-08-16,3 wk ahead cum case,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.990,102185
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,point,NA,102157
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.010,101140
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.025,101280
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.050,101410
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.100,101586
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.150,101711
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.200,101799
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.250,101870
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.300,101926
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.350,101979
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.400,102035
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.450,102091
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.500,102157
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.550,102208
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.600,102283
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.650,102378
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.700,102452
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.750,102523
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.800,102634
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.850,102760
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.900,102963
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.950,103345
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.975,103673
+2021-08-16,4 wk ahead cum case,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.990,104075
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM15,Free State of Thuringia,observed,NA,161
+2021-08-16,0 wk ahead inc case,2021-08-14,GM15,Free State of Thuringia,observed,NA,171
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,point,NA,208
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.010,176
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.025,180
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.050,184
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.100,190
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.150,194
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.200,196
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.250,198
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.300,200
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.350,201
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.400,203
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.450,206
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.500,208
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.550,210
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.600,212
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.650,215
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.700,218
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.750,221
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.800,225
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.850,232
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.900,238
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.950,253
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.975,266
+2021-08-16,1 wk ahead inc case,2021-08-21,GM15,Free State of Thuringia,quantile,0.990,284
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,point,NA,241
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.010,188
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.025,195
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.050,202
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.100,209
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.150,216
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.200,220
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.250,224
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.300,228
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.350,231
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.400,234
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.450,237
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.500,241
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.550,245
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.600,250
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.650,256
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.700,261
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.750,267
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.800,275
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.850,290
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.900,304
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.950,335
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.975,366
+2021-08-16,2 wk ahead inc case,2021-08-28,GM15,Free State of Thuringia,quantile,0.990,410
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,point,NA,281
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.010,202
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.025,210
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.050,221
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.100,231
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.150,242
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.200,247
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.250,253
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.300,258
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.350,263
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.400,269
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.450,274
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.500,281
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.550,286
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.600,296
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.650,305
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.700,313
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.750,323
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.800,338
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.850,363
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.900,387
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.950,445
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.975,505
+2021-08-16,3 wk ahead inc case,2021-09-04,GM15,Free State of Thuringia,quantile,0.990,591
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,point,NA,326
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.010,216
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.025,227
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.050,242
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.100,255
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.150,271
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.200,277
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.250,287
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.300,294
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.350,302
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.400,309
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.450,316
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.500,326
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.550,335
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.600,350
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.650,364
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.700,376
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.750,392
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.800,414
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.850,453
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.900,494
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.950,590
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.975,698
+2021-08-16,4 wk ahead inc case,2021-09-11,GM15,Free State of Thuringia,quantile,0.990,853
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM15,Free State of Thuringia,observed,NA,129369
+2021-08-16,0 wk ahead cum case,2021-08-14,GM15,Free State of Thuringia,observed,NA,129540
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,point,NA,129759
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.010,129712
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.025,129718
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.050,129725
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.100,129734
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.150,129739
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.200,129743
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.250,129747
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.300,129749
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.350,129751
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.400,129753
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.450,129756
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.500,129759
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.550,129762
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.600,129765
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.650,129768
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.700,129772
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.750,129776
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.800,129781
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.850,129787
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.900,129796
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.950,129812
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.975,129826
+2021-08-16,1 wk ahead cum case,2021-08-21,GM15,Free State of Thuringia,quantile,0.990,129847
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,point,NA,130001
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.010,129901
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.025,129914
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.050,129927
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.100,129943
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.150,129956
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.200,129965
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.250,129970
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.300,129976
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.350,129982
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.400,129988
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.450,129993
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.500,130001
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.550,130007
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.600,130014
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.650,130025
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.700,130033
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.750,130043
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.800,130056
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.850,130077
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.900,130099
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.950,130146
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.975,130192
+2021-08-16,2 wk ahead cum case,2021-08-28,GM15,Free State of Thuringia,quantile,0.990,130255
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,point,NA,130281
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.010,130105
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.025,130126
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.050,130149
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.100,130176
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.150,130199
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.200,130213
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.250,130224
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.300,130235
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.350,130245
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.400,130257
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.450,130267
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.500,130281
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.550,130294
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.600,130310
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.650,130330
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.700,130347
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.750,130365
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.800,130392
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.850,130439
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.900,130486
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.950,130589
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.975,130696
+2021-08-16,3 wk ahead cum case,2021-09-04,GM15,Free State of Thuringia,quantile,0.990,130844
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,point,NA,130608
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.010,130321
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.025,130355
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.050,130391
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.100,130429
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.150,130470
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.200,130491
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.250,130511
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.300,130531
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.350,130547
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.400,130568
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.450,130584
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.500,130608
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.550,130630
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.600,130658
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.650,130692
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.700,130722
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.750,130756
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.800,130805
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.850,130893
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.900,130980
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.950,131179
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.975,131390
+2021-08-16,4 wk ahead cum case,2021-09-11,GM15,Free State of Thuringia,quantile,0.990,131695
+2021-08-16,-1 wk ahead inc case,2021-08-07,GM16,Berlin State,observed,NA,1417
+2021-08-16,0 wk ahead inc case,2021-08-14,GM16,Berlin State,observed,NA,2283
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,point,NA,3113
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.010,1906
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.025,2103
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.050,2265
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.100,2458
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.150,2578
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.200,2681
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.250,2758
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.300,2840
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.350,2909
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.400,2972
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.450,3041
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.500,3113
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.550,3181
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.600,3232
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.650,3306
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.700,3387
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.750,3467
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.800,3568
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.850,3692
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.900,3858
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.950,4102
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.975,4314
+2021-08-16,1 wk ahead inc case,2021-08-21,GM16,Berlin State,quantile,0.990,4621
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,point,NA,4423
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.010,1949
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.025,2292
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.050,2588
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.100,2991
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.150,3228
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.200,3435
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.250,3608
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.300,3794
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.350,3949
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.400,4100
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.450,4250
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.500,4423
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.550,4580
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.600,4722
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.650,4910
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.700,5108
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.750,5310
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.800,5558
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.850,5899
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.900,6373
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.950,7069
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.975,7737
+2021-08-16,2 wk ahead inc case,2021-08-28,GM16,Berlin State,quantile,0.990,8662
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,point,NA,6271
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.010,1988
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.025,2501
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.050,2952
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.100,3617
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.150,4047
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.200,4396
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.250,4724
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.300,5081
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.350,5364
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.400,5660
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.450,5955
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.500,6271
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.550,6624
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.600,6919
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.650,7288
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.700,7703
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.750,8162
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.800,8659
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.850,9430
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.900,10529
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.950,12171
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.975,13775
+2021-08-16,3 wk ahead inc case,2021-09-04,GM16,Berlin State,quantile,0.990,16294
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,point,NA,8874
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.010,2020
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.025,2731
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.050,3371
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.100,4386
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.150,5056
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.200,5656
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.250,6194
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.300,6783
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.350,7280
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.400,7808
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.450,8316
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.500,8874
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.550,9565
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.600,10113
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.650,10814
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.700,11647
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.750,12489
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.800,13484
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.850,15069
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.900,17404
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.950,21019
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.975,24664
+2021-08-16,4 wk ahead inc case,2021-09-11,GM16,Berlin State,quantile,0.990,30625
+2021-08-16,-1 wk ahead cum case,2021-08-07,GM16,Berlin State,observed,NA,184111
+2021-08-16,0 wk ahead cum case,2021-08-14,GM16,Berlin State,observed,NA,186394
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,point,NA,189511
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.010,188112
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.025,188342
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.050,188549
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.100,188762
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.150,188906
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.200,189020
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.250,189112
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.300,189196
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.350,189275
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.400,189353
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.450,189435
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.500,189511
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.550,189577
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.600,189646
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.650,189717
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.700,189818
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.750,189917
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.800,190027
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.850,190159
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.900,190334
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.950,190613
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.975,190852
+2021-08-16,1 wk ahead cum case,2021-08-21,GM16,Berlin State,quantile,0.990,191186
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,point,NA,193937
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.010,190079
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.025,190653
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.050,191158
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.100,191764
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.150,192140
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.200,192461
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.250,192721
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.300,192989
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.350,193240
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.400,193456
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.450,193675
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.500,193937
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.550,194187
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.600,194363
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.650,194620
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.700,194912
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.750,195226
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.800,195572
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.850,196048
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.900,196697
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.950,197665
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.975,198540
+2021-08-16,2 wk ahead cum case,2021-08-28,GM16,Berlin State,quantile,0.990,199831
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,point,NA,200225
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.010,192078
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.025,193174
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.050,194110
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.100,195397
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.150,196186
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.200,196862
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.250,197460
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.300,198078
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.350,198588
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.400,199110
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.450,199632
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.500,200225
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.550,200785
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.600,201263
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.650,201919
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.700,202619
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.750,203377
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.800,204250
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.850,205498
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.900,207250
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.950,209829
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.975,212396
+2021-08-16,3 wk ahead cum case,2021-09-04,GM16,Berlin State,quantile,0.990,216078
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,point,NA,209118
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.010,194132
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.025,195916
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.050,197502
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.100,199783
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.150,201270
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.200,202525
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.250,203632
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.300,204872
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.350,205880
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.400,206937
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.450,207961
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.500,209118
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.550,210341
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.600,211415
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.650,212737
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.700,214273
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.750,215926
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.800,217760
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.850,220536
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.900,224584
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.950,230862
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.975,236910
+2021-08-16,4 wk ahead cum case,2021-09-11,GM16,Berlin State,quantile,0.990,246724

--- a/data-processed/FIAS_FZJ-Epi1Ger/2021-08-16-Germany-FIAS_FZJ-Epi1Ger.csv
+++ b/data-processed/FIAS_FZJ-Epi1Ger/2021-08-16-Germany-FIAS_FZJ-Epi1Ger.csv
@@ -1,0 +1,3333 @@
+forecast_date,target,target_end_date,location,location_name,type,quantile,value
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM,Germany,observed,NA,120
+2021-08-16,0 wk ahead inc death,2021-08-14,GM,Germany,observed,NA,86
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,point,NA,174
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.010,159
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.025,161
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.050,164
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.100,166
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.150,167
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.200,168
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.250,169
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.300,170
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.350,171
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.400,171
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.450,173
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.500,174
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.550,175
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.600,176
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.650,177
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.700,178
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.750,179
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.800,180
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.850,182
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.900,185
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.950,189
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.975,194
+2021-08-16,1 wk ahead inc death,2021-08-21,GM,Germany,quantile,0.990,199
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,point,NA,268
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.010,230
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.025,234
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.050,240
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.100,245
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.150,247
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.200,251
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.250,254
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.300,256
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.350,259
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.400,262
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.450,265
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.500,268
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.550,272
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.600,275
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.650,279
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.700,282
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.750,286
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.800,290
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.850,298
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.900,308
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.950,322
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.975,341
+2021-08-16,2 wk ahead inc death,2021-08-28,GM,Germany,quantile,0.990,360
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,point,NA,414
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.010,328
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.025,339
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.050,350
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.100,360
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.150,367
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.200,373
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.250,380
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.300,385
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.350,393
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.400,400
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.450,405
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.500,414
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.550,422
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.600,430
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.650,439
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.700,448
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.750,456
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.800,470
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.850,488
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.900,512
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.950,550
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.975,601
+2021-08-16,3 wk ahead inc death,2021-09-04,GM,Germany,quantile,0.990,655
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,point,NA,638
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.010,469
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.025,489
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.050,508
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.100,529
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.150,544
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.200,554
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.250,569
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.300,577
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.350,593
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.400,610
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.450,620
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.500,638
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.550,652
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.600,669
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.650,689
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.700,709
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.750,725
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.800,759
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.850,797
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.900,850
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.950,937
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.975,1058
+2021-08-16,4 wk ahead inc death,2021-09-11,GM,Germany,quantile,0.990,1189
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM,Germany,observed,NA,91778
+2021-08-16,0 wk ahead cum death,2021-08-14,GM,Germany,observed,NA,91864
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,point,NA,92052
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.010,92035
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.025,92038
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.050,92041
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.100,92043
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.150,92045
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.200,92046
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.250,92047
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.300,92048
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.350,92050
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.400,92051
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.450,92051
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.500,92052
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.550,92053
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.600,92055
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.650,92055
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.700,92057
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.750,92058
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.800,92059
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.850,92061
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.900,92064
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.950,92068
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.975,92072
+2021-08-16,1 wk ahead cum death,2021-08-21,GM,Germany,quantile,0.990,92077
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,point,NA,92320
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.010,92265
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.025,92272
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.050,92281
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.100,92289
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.150,92293
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.200,92298
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.250,92302
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.300,92306
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.350,92308
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.400,92312
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.450,92316
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.500,92320
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.550,92325
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.600,92330
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.650,92335
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.700,92338
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.750,92343
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.800,92350
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.850,92359
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.900,92371
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.950,92390
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.975,92413
+2021-08-16,2 wk ahead cum death,2021-08-28,GM,Germany,quantile,0.990,92436
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,point,NA,92734
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.010,92596
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.025,92612
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.050,92632
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.100,92651
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.150,92658
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.200,92672
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.250,92684
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.300,92690
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.350,92700
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.400,92713
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.450,92723
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.500,92734
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.550,92748
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.600,92761
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.650,92774
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.700,92785
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.750,92800
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.800,92818
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.850,92845
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.900,92883
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.950,92940
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.975,93013
+2021-08-16,3 wk ahead cum death,2021-09-04,GM,Germany,quantile,0.990,93088
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,point,NA,93371
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.010,93065
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.025,93102
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.050,93143
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.100,93179
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.150,93202
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.200,93226
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.250,93251
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.300,93267
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.350,93295
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.400,93322
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.450,93342
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.500,93371
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.550,93401
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.600,93429
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.650,93463
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.700,93495
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.750,93525
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.800,93575
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.850,93642
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.900,93732
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.950,93876
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.975,94067
+2021-08-16,4 wk ahead cum death,2021-09-11,GM,Germany,quantile,0.990,94277
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM01,Baden-Württemberg State,observed,NA,35
+2021-08-16,0 wk ahead inc death,2021-08-14,GM01,Baden-Württemberg State,observed,NA,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,point,NA,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.010,31
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.025,32
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.050,33
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.100,33
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.150,34
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.200,35
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.250,35
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.300,35
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.350,36
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.400,36
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.450,36
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.500,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.550,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.600,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.650,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.700,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.750,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.800,39
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.850,39
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.900,40
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.950,41
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.975,42
+2021-08-16,1 wk ahead inc death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.990,44
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,point,NA,62
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.010,44
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.025,46
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.050,49
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.100,51
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.150,53
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.200,55
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.250,56
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.300,58
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.350,59
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.400,60
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.450,61
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.500,62
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.550,63
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.600,65
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.650,66
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.700,67
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.750,68
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.800,70
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.850,72
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.900,75
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.950,80
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.975,85
+2021-08-16,2 wk ahead inc death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.990,91
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,point,NA,107
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.010,62
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.025,67
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.050,72
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.100,78
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.150,83
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.200,87
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.250,90
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.300,95
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.350,98
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.400,101
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.450,104
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.500,107
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.550,110
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.600,113
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.650,116
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.700,120
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.750,124
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.800,128
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.850,134
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.900,144
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.950,158
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.975,173
+2021-08-16,3 wk ahead inc death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.990,193
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,point,NA,183
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.010,87
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.025,97
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.050,107
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.100,120
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.150,130
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.200,139
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.250,146
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.300,156
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.350,162
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.400,169
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.450,177
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.500,183
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.550,189
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.600,198
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.650,205
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.700,214
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.750,224
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.800,235
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.850,249
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.900,274
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.950,312
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.975,353
+2021-08-16,4 wk ahead inc death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.990,410
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM01,Baden-Württemberg State,observed,NA,10428
+2021-08-16,0 wk ahead cum death,2021-08-14,GM01,Baden-Württemberg State,observed,NA,10434
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,point,NA,10478
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.010,10472
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.025,10473
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.050,10474
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.100,10475
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.150,10475
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.200,10476
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.250,10476
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.300,10477
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.350,10477
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.400,10477
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.450,10478
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.500,10478
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.550,10478
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.600,10478
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.650,10479
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.700,10479
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.750,10480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.800,10480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.850,10480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.900,10481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.950,10482
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.975,10483
+2021-08-16,1 wk ahead cum death,2021-08-21,GM01,Baden-Württemberg State,quantile,0.990,10485
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,point,NA,10540
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.010,10517
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.025,10520
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.050,10523
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.100,10526
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.150,10529
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.200,10531
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.250,10532
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.300,10534
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.350,10536
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.400,10538
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.450,10539
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.500,10540
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.550,10542
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.600,10543
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.650,10545
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.700,10546
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.750,10548
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.800,10550
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.850,10553
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.900,10556
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.950,10562
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.975,10569
+2021-08-16,2 wk ahead cum death,2021-08-28,GM01,Baden-Württemberg State,quantile,0.990,10576
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,point,NA,10647
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.010,10578
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.025,10587
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.050,10595
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.100,10604
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.150,10612
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.200,10618
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.250,10623
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.300,10629
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.350,10634
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.400,10638
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.450,10643
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.500,10647
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.550,10651
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.600,10656
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.650,10660
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.700,10666
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.750,10671
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.800,10678
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.850,10687
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.900,10700
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.950,10721
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.975,10742
+2021-08-16,3 wk ahead cum death,2021-09-04,GM01,Baden-Württemberg State,quantile,0.990,10769
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,point,NA,10830
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.010,10665
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.025,10684
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.050,10702
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.100,10725
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.150,10741
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.200,10757
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.250,10769
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.300,10785
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.350,10796
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.400,10807
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.450,10820
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.500,10830
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.550,10842
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.600,10852
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.650,10866
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.700,10880
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.750,10895
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.800,10913
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.850,10935
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.900,10974
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.950,11032
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.975,11095
+2021-08-16,4 wk ahead cum death,2021-09-11,GM01,Baden-Württemberg State,quantile,0.990,11178
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM02,Free State of Bavaria,observed,NA,21
+2021-08-16,0 wk ahead inc death,2021-08-14,GM02,Free State of Bavaria,observed,NA,12
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,point,NA,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.010,33
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.025,33
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.050,34
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.100,35
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.150,35
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.200,36
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.250,36
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.300,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.350,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.400,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.450,37
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.500,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.550,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.600,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.650,38
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.700,39
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.750,39
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.800,39
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.850,40
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.900,40
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.950,41
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.975,42
+2021-08-16,1 wk ahead inc death,2021-08-21,GM02,Free State of Bavaria,quantile,0.990,43
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,point,NA,64
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.010,47
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.025,49
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.050,52
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.100,54
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.150,56
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.200,57
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.250,59
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.300,60
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.350,61
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.400,62
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.450,63
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.500,64
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.550,64
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.600,66
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.650,66
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.700,67
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.750,68
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.800,70
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.850,72
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.900,74
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.950,77
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.975,81
+2021-08-16,2 wk ahead inc death,2021-08-28,GM02,Free State of Bavaria,quantile,0.990,86
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,point,NA,109
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.010,67
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.025,73
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.050,80
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.100,85
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.150,89
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.200,92
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.250,95
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.300,98
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.350,102
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.400,104
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.450,107
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.500,109
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.550,110
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.600,114
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.650,116
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.700,119
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.750,122
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.800,125
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.850,132
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.900,137
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.950,148
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.975,157
+2021-08-16,3 wk ahead inc death,2021-09-04,GM02,Free State of Bavaria,quantile,0.990,172
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,point,NA,186
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.010,96
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.025,108
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.050,122
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.100,133
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.150,142
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.200,149
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.250,156
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.300,162
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.350,169
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.400,175
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.450,181
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.500,186
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.550,190
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.600,197
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.650,202
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.700,210
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.750,217
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.800,225
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.850,243
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.900,256
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.950,282
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.975,308
+2021-08-16,4 wk ahead inc death,2021-09-11,GM02,Free State of Bavaria,quantile,0.990,346
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM02,Free State of Bavaria,observed,NA,15359
+2021-08-16,0 wk ahead cum death,2021-08-14,GM02,Free State of Bavaria,observed,NA,15371
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,point,NA,15414
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.010,15409
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.025,15410
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.050,15411
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.100,15411
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.150,15412
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.200,15412
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.250,15413
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.300,15413
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.350,15413
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.400,15413
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.450,15414
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.500,15414
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.550,15414
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.600,15414
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.650,15415
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.700,15415
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.750,15415
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.800,15415
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.850,15416
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.900,15417
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.950,15417
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.975,15418
+2021-08-16,1 wk ahead cum death,2021-08-21,GM02,Free State of Bavaria,quantile,0.990,15419
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,point,NA,15477
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.010,15456
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.025,15460
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.050,15463
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.100,15466
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.150,15468
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.200,15470
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.250,15471
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.300,15473
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.350,15474
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.400,15476
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.450,15477
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.500,15477
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.550,15478
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.600,15480
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.650,15481
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.700,15482
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.750,15483
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.800,15485
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.850,15488
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.900,15490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.950,15495
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.975,15499
+2021-08-16,2 wk ahead cum death,2021-08-28,GM02,Free State of Bavaria,quantile,0.990,15505
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,point,NA,15586
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.010,15523
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.025,15533
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.050,15542
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.100,15551
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.150,15557
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.200,15562
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.250,15567
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.300,15571
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.350,15576
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.400,15580
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.450,15584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.500,15586
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.550,15589
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.600,15594
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.650,15597
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.700,15601
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.750,15605
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.800,15610
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.850,15620
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.900,15628
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.950,15642
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.975,15655
+2021-08-16,3 wk ahead cum death,2021-09-04,GM02,Free State of Bavaria,quantile,0.990,15676
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,point,NA,15772
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.010,15619
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.025,15642
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.050,15665
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.100,15684
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.150,15700
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.200,15711
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.250,15722
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.300,15733
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.350,15745
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.400,15755
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.450,15765
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.500,15772
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.550,15778
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.600,15791
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.650,15799
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.700,15810
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.750,15821
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.800,15835
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.850,15862
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.900,15883
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.950,15925
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.975,15963
+2021-08-16,4 wk ahead cum death,2021-09-11,GM02,Free State of Bavaria,quantile,0.990,16023
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM03,Free Hanseatic City of Bremen,observed,NA,0
+2021-08-16,0 wk ahead inc death,2021-08-14,GM03,Free Hanseatic City of Bremen,observed,NA,1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,point,NA,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.010,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.025,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.050,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.100,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.150,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.200,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.250,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.300,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.350,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.400,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.450,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.500,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.550,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.600,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.650,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.700,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.750,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.800,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.850,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.900,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.950,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.975,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.990,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,point,NA,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.010,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.025,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.050,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.100,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.150,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.200,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.250,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.300,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.350,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.400,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.450,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.500,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.550,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.600,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.650,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.700,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.750,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.800,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.850,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.900,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.950,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.975,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.990,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,point,NA,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.010,-5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.025,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.050,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.100,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.150,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.200,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.250,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.300,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.350,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.400,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.450,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.500,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.550,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.600,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.650,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.700,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.750,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.800,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.850,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.900,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.950,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.975,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.990,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,point,NA,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.010,-9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.025,-8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.050,-7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.100,-6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.150,-6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.200,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.250,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.300,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.350,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.400,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.450,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.500,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.550,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.600,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.650,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.700,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.750,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.800,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.850,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.900,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.950,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.975,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.990,-2
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM03,Free Hanseatic City of Bremen,observed,NA,493
+2021-08-16,0 wk ahead cum death,2021-08-14,GM03,Free Hanseatic City of Bremen,observed,NA,494
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,point,NA,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.010,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.025,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.050,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.100,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.150,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.200,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.250,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.300,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.350,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.400,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.450,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.500,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.550,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.600,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.650,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.700,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.750,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.800,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.850,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.900,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.950,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.975,492
+2021-08-16,1 wk ahead cum death,2021-08-21,GM03,Free Hanseatic City of Bremen,quantile,0.990,492
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,point,NA,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.010,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.025,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.050,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.100,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.150,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.200,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.250,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.300,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.350,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.400,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.450,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.500,490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.550,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.600,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.650,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.700,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.750,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.800,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.850,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.900,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.950,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.975,491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM03,Free Hanseatic City of Bremen,quantile,0.990,491
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,point,NA,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.010,485
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.025,486
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.050,486
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.100,487
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.150,487
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.200,487
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.250,487
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.300,487
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.350,487
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.400,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.450,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.500,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.550,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.600,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.650,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.700,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.750,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.800,488
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.850,489
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.900,489
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.950,489
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.975,489
+2021-08-16,3 wk ahead cum death,2021-09-04,GM03,Free Hanseatic City of Bremen,quantile,0.990,489
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,point,NA,483
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.010,476
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.025,478
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.050,479
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.100,480
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.150,481
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.200,482
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.250,482
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.300,482
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.350,483
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.400,483
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.450,483
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.500,483
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.550,484
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.600,484
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.650,484
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.700,484
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.750,485
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.800,485
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.850,485
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.900,486
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.950,486
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.975,487
+2021-08-16,4 wk ahead cum death,2021-09-11,GM03,Free Hanseatic City of Bremen,quantile,0.990,487
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM04,Free Hanseatic City of Hamburg,observed,NA,9
+2021-08-16,0 wk ahead inc death,2021-08-14,GM04,Free Hanseatic City of Hamburg,observed,NA,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,point,NA,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.010,18
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.025,19
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.050,19
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.100,19
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.150,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.200,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.250,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.300,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.350,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.400,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.450,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.500,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.550,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.600,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.650,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.700,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.750,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.800,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.850,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.900,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.950,23
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.975,23
+2021-08-16,1 wk ahead inc death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.990,24
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,point,NA,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.010,26
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.025,28
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.050,29
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.100,31
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.150,32
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.200,33
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.250,33
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.300,34
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.350,34
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.400,35
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.450,35
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.500,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.550,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.600,37
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.650,37
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.700,38
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.750,39
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.800,40
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.850,41
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.900,42
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.950,44
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.975,46
+2021-08-16,2 wk ahead inc death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.990,49
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,point,NA,62
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.010,38
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.025,42
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.050,45
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.100,48
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.150,51
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.200,53
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.250,55
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.300,57
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.350,58
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.400,59
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.450,60
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.500,62
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.550,63
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.600,65
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.650,66
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.700,68
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.750,70
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.800,72
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.850,75
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.900,79
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.950,85
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.975,92
+2021-08-16,3 wk ahead inc death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.990,100
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,point,NA,107
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.010,54
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.025,63
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.050,70
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.100,77
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.150,82
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.200,88
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.250,92
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.300,95
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.350,98
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.400,101
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.450,104
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.500,107
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.550,110
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.600,113
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.650,118
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.700,122
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.750,127
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.800,132
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.850,140
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.900,148
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.950,166
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.975,182
+2021-08-16,4 wk ahead inc death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.990,205
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM04,Free Hanseatic City of Hamburg,observed,NA,1624
+2021-08-16,0 wk ahead cum death,2021-08-14,GM04,Free Hanseatic City of Hamburg,observed,NA,1634
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,point,NA,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.010,1654
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.025,1655
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.050,1655
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.100,1655
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.150,1656
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.200,1656
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.250,1656
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.300,1656
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.350,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.400,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.450,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.500,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.550,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.600,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.650,1657
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.700,1658
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.750,1658
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.800,1658
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.850,1658
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.900,1659
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.950,1659
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.975,1660
+2021-08-16,1 wk ahead cum death,2021-08-21,GM04,Free Hanseatic City of Hamburg,quantile,0.990,1660
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,point,NA,1693
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.010,1680
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.025,1683
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.050,1684
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.100,1686
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.150,1687
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.200,1689
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.250,1690
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.300,1690
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.350,1691
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.400,1692
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.450,1692
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.500,1693
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.550,1693
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.600,1694
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.650,1695
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.700,1695
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.750,1696
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.800,1698
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.850,1699
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.900,1700
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.950,1703
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.975,1706
+2021-08-16,2 wk ahead cum death,2021-08-28,GM04,Free Hanseatic City of Hamburg,quantile,0.990,1709
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,point,NA,1754
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.010,1718
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.025,1725
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.050,1730
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.100,1735
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.150,1738
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.200,1743
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.250,1745
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.300,1747
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.350,1749
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.400,1751
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.450,1753
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.500,1754
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.550,1757
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.600,1758
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.650,1761
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.700,1763
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.750,1767
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.800,1770
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.850,1774
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.900,1779
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.950,1788
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.975,1797
+2021-08-16,3 wk ahead cum death,2021-09-04,GM04,Free Hanseatic City of Hamburg,quantile,0.990,1809
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,point,NA,1861
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.010,1772
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.025,1788
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.050,1799
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.100,1811
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.150,1821
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.200,1830
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.250,1837
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.300,1842
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.350,1846
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.400,1853
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.450,1856
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.500,1861
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.550,1866
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.600,1872
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.650,1879
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.700,1886
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.750,1893
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.800,1902
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.850,1913
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.900,1927
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.950,1954
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.975,1979
+2021-08-16,4 wk ahead cum death,2021-09-11,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2014
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM05,Hesse State,observed,NA,6
+2021-08-16,0 wk ahead inc death,2021-08-14,GM05,Hesse State,observed,NA,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,point,NA,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.010,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.025,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.050,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.100,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.150,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.200,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.250,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.300,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.350,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.400,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.450,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.500,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.550,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.600,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.650,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.700,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.750,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.800,12
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.850,12
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.900,12
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.950,12
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.975,13
+2021-08-16,1 wk ahead inc death,2021-08-21,GM05,Hesse State,quantile,0.990,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,point,NA,17
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.010,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.025,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.050,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.100,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.150,15
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.200,15
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.250,16
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.300,16
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.350,16
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.400,17
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.450,17
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.500,17
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.550,18
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.600,18
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.650,18
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.700,19
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.750,19
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.800,20
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.850,20
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.900,21
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.950,22
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.975,24
+2021-08-16,2 wk ahead inc death,2021-08-28,GM05,Hesse State,quantile,0.990,26
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,point,NA,28
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.010,15
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.025,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.050,19
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.100,21
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.150,22
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.200,23
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.250,23
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.300,24
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.350,25
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.400,26
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.450,27
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.500,28
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.550,28
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.600,29
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.650,30
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.700,31
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.750,32
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.800,34
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.850,35
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.900,37
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.950,41
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.975,45
+2021-08-16,3 wk ahead inc death,2021-09-04,GM05,Hesse State,quantile,0.990,51
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,point,NA,44
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.010,20
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.025,23
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.050,26
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.100,29
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.150,32
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.200,34
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.250,35
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.300,37
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.350,39
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.400,41
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.450,42
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.500,44
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.550,46
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.600,48
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.650,50
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.700,52
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.750,54
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.800,58
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.850,61
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.900,67
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.950,76
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.975,86
+2021-08-16,4 wk ahead inc death,2021-09-11,GM05,Hesse State,quantile,0.990,101
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM05,Hesse State,observed,NA,7593
+2021-08-16,0 wk ahead cum death,2021-08-14,GM05,Hesse State,observed,NA,7602
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,point,NA,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.010,7611
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.025,7611
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.050,7611
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.100,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.150,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.200,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.250,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.300,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.350,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.400,7612
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.450,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.500,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.550,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.600,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.650,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.700,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.750,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.800,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.850,7613
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.900,7614
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.950,7614
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.975,7614
+2021-08-16,1 wk ahead cum death,2021-08-21,GM05,Hesse State,quantile,0.990,7615
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,point,NA,7630
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.010,7623
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.025,7624
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.050,7625
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.100,7626
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.150,7627
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.200,7627
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.250,7628
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.300,7628
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.350,7629
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.400,7629
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.450,7630
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.500,7630
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.550,7630
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.600,7631
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.650,7631
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.700,7632
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.750,7632
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.800,7633
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.850,7634
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.900,7635
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.950,7636
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.975,7638
+2021-08-16,2 wk ahead cum death,2021-08-28,GM05,Hesse State,quantile,0.990,7640
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,point,NA,7658
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.010,7638
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.025,7641
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.050,7643
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.100,7647
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.150,7649
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.200,7650
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.250,7651
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.300,7653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.350,7654
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.400,7655
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.450,7656
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.500,7658
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.550,7659
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.600,7660
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.650,7661
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.700,7663
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.750,7664
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.800,7666
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.850,7669
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.900,7672
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.950,7677
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.975,7683
+2021-08-16,3 wk ahead cum death,2021-09-04,GM05,Hesse State,quantile,0.990,7691
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,point,NA,7702
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.010,7658
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.025,7663
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.050,7669
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.100,7676
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.150,7680
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.200,7684
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.250,7687
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.300,7690
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.350,7693
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.400,7696
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.450,7699
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.500,7702
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.550,7705
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.600,7708
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.650,7711
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.700,7715
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.750,7719
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.800,7724
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.850,7730
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.900,7739
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.950,7754
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.975,7770
+2021-08-16,4 wk ahead cum death,2021-09-11,GM05,Hesse State,quantile,0.990,7792
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM06,Lower Saxony State,observed,NA,2
+2021-08-16,0 wk ahead inc death,2021-08-14,GM06,Lower Saxony State,observed,NA,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,point,NA,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.010,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.025,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.050,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.100,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.150,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.200,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.250,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.300,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.350,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.400,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.450,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.500,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.550,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.600,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.650,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.700,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.750,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.800,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.850,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.900,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.950,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.975,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM06,Lower Saxony State,quantile,0.990,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,point,NA,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.010,9
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.025,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.050,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.100,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.150,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.200,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.250,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.300,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.350,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.400,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.450,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.500,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.550,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.600,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.650,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.700,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.750,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.800,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.850,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.900,15
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.950,16
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.975,17
+2021-08-16,2 wk ahead inc death,2021-08-28,GM06,Lower Saxony State,quantile,0.990,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,point,NA,15
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.010,10
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.025,11
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.050,11
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.100,12
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.150,12
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.200,13
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.250,13
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.300,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.350,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.400,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.450,15
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.500,15
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.550,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.600,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.650,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.700,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.750,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.800,19
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.850,20
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.900,21
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.950,23
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.975,25
+2021-08-16,3 wk ahead inc death,2021-09-04,GM06,Lower Saxony State,quantile,0.990,29
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,point,NA,19
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.010,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.025,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.050,12
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.100,13
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.150,14
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.200,15
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.250,15
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.300,16
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.350,17
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.400,18
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.450,18
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.500,19
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.550,20
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.600,21
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.650,22
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.700,23
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.750,24
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.800,25
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.850,27
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.900,29
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.950,34
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.975,38
+2021-08-16,4 wk ahead inc death,2021-09-11,GM06,Lower Saxony State,quantile,0.990,45
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM06,Lower Saxony State,observed,NA,5819
+2021-08-16,0 wk ahead cum death,2021-08-14,GM06,Lower Saxony State,observed,NA,5826
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,point,NA,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.010,5836
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.025,5836
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.050,5836
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.100,5836
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.150,5836
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.200,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.250,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.300,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.350,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.400,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.450,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.500,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.550,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.600,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.650,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.700,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.750,5837
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.800,5838
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.850,5838
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.900,5838
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.950,5838
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.975,5839
+2021-08-16,1 wk ahead cum death,2021-08-21,GM06,Lower Saxony State,quantile,0.990,5839
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,point,NA,5849
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.010,5845
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.025,5846
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.050,5846
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.100,5847
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.150,5847
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.200,5848
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.250,5848
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.300,5848
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.350,5849
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.400,5849
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.450,5849
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.500,5849
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.550,5850
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.600,5850
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.650,5850
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.700,5851
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.750,5851
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.800,5852
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.850,5852
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.900,5853
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.950,5854
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.975,5855
+2021-08-16,2 wk ahead cum death,2021-08-28,GM06,Lower Saxony State,quantile,0.990,5857
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,point,NA,5865
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.010,5855
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.025,5856
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.050,5857
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.100,5858
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.150,5859
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.200,5860
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.250,5861
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.300,5862
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.350,5863
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.400,5863
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.450,5864
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.500,5865
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.550,5865
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.600,5866
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.650,5867
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.700,5868
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.750,5869
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.800,5870
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.850,5872
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.900,5874
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.950,5877
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.975,5881
+2021-08-16,3 wk ahead cum death,2021-09-04,GM06,Lower Saxony State,quantile,0.990,5885
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,point,NA,5884
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.010,5866
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.025,5868
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.050,5870
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.100,5872
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.150,5874
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.200,5875
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.250,5876
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.300,5878
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.350,5879
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.400,5881
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.450,5882
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.500,5884
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.550,5885
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.600,5887
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.650,5889
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.700,5891
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.750,5893
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.800,5896
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.850,5898
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.900,5903
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.950,5911
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.975,5919
+2021-08-16,4 wk ahead cum death,2021-09-11,GM06,Lower Saxony State,quantile,0.990,5930
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM07,North Rhine-Westphalia State,observed,NA,13
+2021-08-16,0 wk ahead inc death,2021-08-14,GM07,North Rhine-Westphalia State,observed,NA,15
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,point,NA,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.010,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.025,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.050,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.100,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.150,20
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.200,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.250,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.300,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.350,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.400,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.450,21
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.500,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.550,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.600,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.650,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.700,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.750,22
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.800,23
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.850,23
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.900,23
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.950,24
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.975,24
+2021-08-16,1 wk ahead inc death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.990,25
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,point,NA,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.010,29
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.025,30
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.050,30
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.100,31
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.150,32
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.200,32
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.250,33
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.300,33
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.350,34
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.400,34
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.450,35
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.500,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.550,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.600,36
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.650,37
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.700,38
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.750,38
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.800,39
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.850,40
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.900,41
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.950,43
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.975,45
+2021-08-16,2 wk ahead inc death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.990,48
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,point,NA,59
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.010,43
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.025,45
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.050,46
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.100,48
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.150,49
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.200,51
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.250,52
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.300,53
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.350,54
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.400,56
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.450,57
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.500,59
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.550,60
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.600,61
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.650,62
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.700,64
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.750,66
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.800,68
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.850,71
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.900,74
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.950,79
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.975,86
+2021-08-16,3 wk ahead inc death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.990,95
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,point,NA,97
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.010,64
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.025,67
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.050,69
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.100,74
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.150,76
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.200,79
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.250,82
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.300,84
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.350,87
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.400,90
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.450,93
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.500,97
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.550,99
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.600,102
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.650,105
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.700,108
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.750,113
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.800,118
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.850,125
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.900,132
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.950,145
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.975,162
+2021-08-16,4 wk ahead inc death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.990,185
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM07,North Rhine-Westphalia State,observed,NA,17305
+2021-08-16,0 wk ahead cum death,2021-08-14,GM07,North Rhine-Westphalia State,observed,NA,17320
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,point,NA,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.010,17339
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.025,17340
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.050,17340
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.100,17340
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.150,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.200,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.250,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.300,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.350,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.400,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.450,17341
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.500,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.550,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.600,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.650,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.700,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.750,17342
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.800,17343
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.850,17343
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.900,17343
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.950,17344
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.975,17344
+2021-08-16,1 wk ahead cum death,2021-08-21,GM07,North Rhine-Westphalia State,quantile,0.990,17345
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,point,NA,17377
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.010,17369
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.025,17370
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.050,17370
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.100,17372
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.150,17372
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.200,17373
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.250,17374
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.300,17375
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.350,17375
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.400,17376
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.450,17377
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.500,17377
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.550,17378
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.600,17378
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.650,17379
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.700,17380
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.750,17380
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.800,17382
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.850,17383
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.900,17384
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.950,17387
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.975,17389
+2021-08-16,2 wk ahead cum death,2021-08-28,GM07,North Rhine-Westphalia State,quantile,0.990,17393
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,point,NA,17436
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.010,17412
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.025,17414
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.050,17416
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.100,17420
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.150,17422
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.200,17424
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.250,17426
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.300,17428
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.350,17429
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.400,17431
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.450,17434
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.500,17436
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.550,17438
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.600,17439
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.650,17441
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.700,17444
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.750,17446
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.800,17449
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.850,17453
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.900,17458
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.950,17466
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.975,17475
+2021-08-16,3 wk ahead cum death,2021-09-04,GM07,North Rhine-Westphalia State,quantile,0.990,17488
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,point,NA,17533
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.010,17476
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.025,17482
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.050,17486
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.100,17493
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.150,17498
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.200,17502
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.250,17508
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.300,17512
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.350,17516
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.400,17521
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.450,17527
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.500,17533
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.550,17536
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.600,17541
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.650,17546
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.700,17552
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.750,17558
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.800,17567
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.850,17578
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.900,17590
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.950,17610
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.975,17637
+2021-08-16,4 wk ahead cum death,2021-09-11,GM07,North Rhine-Westphalia State,quantile,0.990,17672
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM08,Rhineland-Palatinate State,observed,NA,5
+2021-08-16,0 wk ahead inc death,2021-08-14,GM08,Rhineland-Palatinate State,observed,NA,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,point,NA,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.010,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.025,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.050,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.100,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.150,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.200,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.250,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.300,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.350,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.400,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.450,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.500,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.550,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.600,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.650,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.700,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.750,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.800,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.850,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.900,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.950,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.975,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.990,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,point,NA,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.010,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.025,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.050,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.100,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.150,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.200,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.250,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.300,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.350,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.400,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.450,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.500,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.550,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.600,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.650,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.700,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.750,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.800,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.850,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.900,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.950,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.975,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.990,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,point,NA,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.010,3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.025,3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.050,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.100,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.150,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.200,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.250,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.300,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.350,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.400,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.450,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.500,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.550,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.600,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.650,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.700,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.750,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.800,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.850,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.900,8
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.950,9
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.975,10
+2021-08-16,3 wk ahead inc death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.990,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,point,NA,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.010,3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.025,4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.050,5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.100,5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.150,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.200,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.250,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.300,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.350,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.400,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.450,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.500,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.550,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.600,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.650,10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.700,10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.750,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.800,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.850,12
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.900,13
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.950,15
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.975,17
+2021-08-16,4 wk ahead inc death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.990,20
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM08,Rhineland-Palatinate State,observed,NA,3911
+2021-08-16,0 wk ahead cum death,2021-08-14,GM08,Rhineland-Palatinate State,observed,NA,3916
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,point,NA,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.010,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.025,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.050,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.100,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.150,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.200,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.250,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.300,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.350,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.400,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.450,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.500,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.550,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.600,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.650,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.700,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.750,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.800,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.850,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.900,3917
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.950,3918
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.975,3918
+2021-08-16,1 wk ahead cum death,2021-08-21,GM08,Rhineland-Palatinate State,quantile,0.990,3918
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,point,NA,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.010,3919
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.025,3920
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.050,3920
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.100,3920
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.150,3920
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.200,3920
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.250,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.300,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.350,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.400,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.450,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.500,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.550,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.600,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.650,3921
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.700,3922
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.750,3922
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.800,3922
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.850,3922
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.900,3922
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.950,3923
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.975,3923
+2021-08-16,2 wk ahead cum death,2021-08-28,GM08,Rhineland-Palatinate State,quantile,0.990,3923
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,point,NA,3927
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.010,3922
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.025,3923
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.050,3924
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.100,3924
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.150,3925
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.200,3925
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.250,3925
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.300,3926
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.350,3926
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.400,3926
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.450,3927
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.500,3927
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.550,3927
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.600,3927
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.650,3928
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.700,3928
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.750,3928
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.800,3929
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.850,3929
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.900,3930
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.950,3931
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.975,3932
+2021-08-16,3 wk ahead cum death,2021-09-04,GM08,Rhineland-Palatinate State,quantile,0.990,3934
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,point,NA,3935
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.010,3926
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.025,3927
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.050,3928
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.100,3929
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.150,3930
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.200,3931
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.250,3932
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.300,3933
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.350,3933
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.400,3934
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.450,3935
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.500,3935
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.550,3936
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.600,3936
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.650,3937
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.700,3938
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.750,3939
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.800,3940
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.850,3941
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.900,3943
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.950,3946
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.975,3949
+2021-08-16,4 wk ahead cum death,2021-09-11,GM08,Rhineland-Palatinate State,quantile,0.990,3954
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM09,Saarland State,observed,NA,1
+2021-08-16,0 wk ahead inc death,2021-08-14,GM09,Saarland State,observed,NA,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,point,NA,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.010,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.025,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.050,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.100,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.150,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.200,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.250,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.300,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.350,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.400,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.450,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.500,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.550,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.600,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.650,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.700,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.750,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.800,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.850,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.900,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.950,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.975,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM09,Saarland State,quantile,0.990,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,point,NA,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.010,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.025,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.050,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.100,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.150,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.200,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.250,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.300,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.350,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.400,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.450,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.500,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.550,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.600,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.650,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.700,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.750,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.800,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.850,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.900,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.950,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.975,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM09,Saarland State,quantile,0.990,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,point,NA,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.010,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.025,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.050,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.100,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.150,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.200,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.250,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.300,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.350,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.400,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.450,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.500,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.550,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.600,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.650,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.700,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.750,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.800,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.850,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.900,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.950,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.975,8
+2021-08-16,3 wk ahead inc death,2021-09-04,GM09,Saarland State,quantile,0.990,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,point,NA,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.010,5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.025,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.050,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.100,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.150,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.200,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.250,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.300,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.350,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.400,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.450,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.500,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.550,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.600,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.650,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.700,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.750,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.800,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.850,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.900,10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.950,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.975,13
+2021-08-16,4 wk ahead inc death,2021-09-11,GM09,Saarland State,quantile,0.990,16
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM09,Saarland State,observed,NA,1030
+2021-08-16,0 wk ahead cum death,2021-08-14,GM09,Saarland State,observed,NA,1030
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,point,NA,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.010,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.025,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.050,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.100,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.150,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.200,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.250,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.300,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.350,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.400,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.450,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.500,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.550,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.600,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.650,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.700,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.750,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.800,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.850,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.900,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.950,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.975,1033
+2021-08-16,1 wk ahead cum death,2021-08-21,GM09,Saarland State,quantile,0.990,1033
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,point,NA,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.010,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.025,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.050,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.100,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.150,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.200,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.250,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.300,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.350,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.400,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.450,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.500,1036
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.550,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.600,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.650,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.700,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.750,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.800,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.850,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.900,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.950,1037
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.975,1038
+2021-08-16,2 wk ahead cum death,2021-08-28,GM09,Saarland State,quantile,0.990,1038
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,point,NA,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.010,1039
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.025,1040
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.050,1040
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.100,1040
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.150,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.200,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.250,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.300,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.350,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.400,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.450,1041
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.500,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.550,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.600,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.650,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.700,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.750,1042
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.800,1043
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.850,1043
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.900,1043
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.950,1044
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.975,1046
+2021-08-16,3 wk ahead cum death,2021-09-04,GM09,Saarland State,quantile,0.990,1047
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,point,NA,1049
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.010,1045
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.025,1045
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.050,1046
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.100,1047
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.150,1047
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.200,1047
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.250,1048
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.300,1048
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.350,1048
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.400,1048
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.450,1049
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.500,1049
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.550,1049
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.600,1050
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.650,1050
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.700,1050
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.750,1051
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.800,1052
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.850,1052
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.900,1053
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.950,1056
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.975,1059
+2021-08-16,4 wk ahead cum death,2021-09-11,GM09,Saarland State,quantile,0.990,1063
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM10,Schleswig-Holstein State,observed,NA,1
+2021-08-16,0 wk ahead inc death,2021-08-14,GM10,Schleswig-Holstein State,observed,NA,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,point,NA,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.010,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.025,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.050,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.100,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.150,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.200,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.250,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.300,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.350,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.400,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.450,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.500,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.550,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.600,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.650,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.700,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.750,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.800,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.850,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.900,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.950,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.975,3
+2021-08-16,1 wk ahead inc death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.990,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,point,NA,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.010,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.025,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.050,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.100,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.150,3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.200,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.250,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.300,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.350,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.400,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.450,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.500,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.550,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.600,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.650,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.700,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.750,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.800,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.850,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.900,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.950,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.975,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.990,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,point,NA,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.010,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.025,4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.050,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.100,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.150,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.200,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.250,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.300,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.350,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.400,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.450,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.500,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.550,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.600,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.650,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.700,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.750,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.800,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.850,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.900,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.950,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.975,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.990,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,point,NA,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.010,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.025,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.050,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.100,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.150,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.200,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.250,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.300,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.350,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.400,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.450,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.500,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.550,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.600,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.650,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.700,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.750,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.800,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.850,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.900,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.950,10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.975,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.990,13
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM10,Schleswig-Holstein State,observed,NA,1639
+2021-08-16,0 wk ahead cum death,2021-08-14,GM10,Schleswig-Holstein State,observed,NA,1641
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,point,NA,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.010,1643
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.025,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.050,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.100,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.150,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.200,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.250,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.300,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.350,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.400,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.450,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.500,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.550,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.600,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.650,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.700,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.750,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.800,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.850,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.900,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.950,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.975,1644
+2021-08-16,1 wk ahead cum death,2021-08-21,GM10,Schleswig-Holstein State,quantile,0.990,1644
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,point,NA,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.010,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.025,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.050,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.100,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.150,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.200,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.250,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.300,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.350,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.400,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.450,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.500,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.550,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.600,1647
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.650,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.700,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.750,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.800,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.850,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.900,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.950,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.975,1648
+2021-08-16,2 wk ahead cum death,2021-08-28,GM10,Schleswig-Holstein State,quantile,0.990,1649
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,point,NA,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.010,1651
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.025,1651
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.050,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.100,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.150,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.200,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.250,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.300,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.350,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.400,1652
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.450,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.500,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.550,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.600,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.650,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.700,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.750,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.800,1653
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.850,1654
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.900,1654
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.950,1655
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.975,1655
+2021-08-16,3 wk ahead cum death,2021-09-04,GM10,Schleswig-Holstein State,quantile,0.990,1656
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,point,NA,1660
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.010,1657
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.025,1657
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.050,1658
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.100,1658
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.150,1659
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.200,1659
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.250,1659
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.300,1659
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.350,1660
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.400,1660
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.450,1660
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.500,1660
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.550,1660
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.600,1661
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.650,1661
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.700,1661
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.750,1662
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.800,1662
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.850,1663
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.900,1663
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.950,1665
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.975,1667
+2021-08-16,4 wk ahead cum death,2021-09-11,GM10,Schleswig-Holstein State,quantile,0.990,1669
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM11,Brandenburg State,observed,NA,1
+2021-08-16,0 wk ahead inc death,2021-08-14,GM11,Brandenburg State,observed,NA,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,point,NA,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.010,-2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.025,-2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.050,-2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.100,-2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.150,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.200,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.250,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.300,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.350,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.400,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.450,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.500,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.550,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.600,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.650,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.700,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.750,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.800,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.850,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.900,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.950,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.975,-1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM11,Brandenburg State,quantile,0.990,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,point,NA,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.010,-3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.025,-3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.050,-3
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.100,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.150,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.200,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.250,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.300,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.350,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.400,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.450,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.500,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.550,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.600,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.650,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.700,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.750,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.800,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.850,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.900,-2
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.950,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.975,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM11,Brandenburg State,quantile,0.990,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,point,NA,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.010,-6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.025,-5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.050,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.100,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.150,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.200,-4
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.250,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.300,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.350,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.400,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.450,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.500,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.550,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.600,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.650,-3
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.700,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.750,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.800,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.850,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.900,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.950,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.975,-2
+2021-08-16,3 wk ahead inc death,2021-09-04,GM11,Brandenburg State,quantile,0.990,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,point,NA,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.010,-10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.025,-8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.050,-7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.100,-6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.150,-6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.200,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.250,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.300,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.350,-5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.400,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.450,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.500,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.550,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.600,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.650,-4
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.700,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.750,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.800,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.850,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.900,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.950,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.975,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM11,Brandenburg State,quantile,0.990,-2
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM11,Brandenburg State,observed,NA,3818
+2021-08-16,0 wk ahead cum death,2021-08-14,GM11,Brandenburg State,observed,NA,3818
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,point,NA,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.010,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.025,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.050,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.100,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.150,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.200,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.250,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.300,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.350,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.400,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.450,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.500,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.550,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.600,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.650,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.700,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.750,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.800,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.850,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.900,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.950,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.975,3816
+2021-08-16,1 wk ahead cum death,2021-08-21,GM11,Brandenburg State,quantile,0.990,3817
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,point,NA,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.010,3813
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.025,3813
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.050,3813
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.100,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.150,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.200,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.250,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.300,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.350,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.400,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.450,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.500,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.550,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.600,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.650,3814
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.700,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.750,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.800,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.850,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.900,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.950,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.975,3815
+2021-08-16,2 wk ahead cum death,2021-08-28,GM11,Brandenburg State,quantile,0.990,3815
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,point,NA,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.010,3807
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.025,3808
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.050,3809
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.100,3810
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.150,3810
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.200,3810
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.250,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.300,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.350,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.400,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.450,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.500,3811
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.550,3812
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.600,3812
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.650,3812
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.700,3812
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.750,3812
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.800,3812
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.850,3813
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.900,3813
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.950,3813
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.975,3813
+2021-08-16,3 wk ahead cum death,2021-09-04,GM11,Brandenburg State,quantile,0.990,3814
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,point,NA,3807
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.010,3797
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.025,3800
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.050,3802
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.100,3803
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.150,3804
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.200,3805
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.250,3805
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.300,3806
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.350,3806
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.400,3807
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.450,3807
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.500,3807
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.550,3808
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.600,3808
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.650,3808
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.700,3809
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.750,3809
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.800,3809
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.850,3810
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.900,3810
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.950,3811
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.975,3812
+2021-08-16,4 wk ahead cum death,2021-09-11,GM11,Brandenburg State,quantile,0.990,3812
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM12,Mecklenburg-Western Pomerania State,observed,NA,3
+2021-08-16,0 wk ahead inc death,2021-08-14,GM12,Mecklenburg-Western Pomerania State,observed,NA,1
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,point,NA,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,point,NA,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,point,NA,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,point,NA,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,0
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM12,Mecklenburg-Western Pomerania State,observed,NA,1183
+2021-08-16,0 wk ahead cum death,2021-08-14,GM12,Mecklenburg-Western Pomerania State,observed,NA,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,point,NA,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1184
+2021-08-16,1 wk ahead cum death,2021-08-21,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,point,NA,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1184
+2021-08-16,2 wk ahead cum death,2021-08-28,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1184
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,point,NA,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,point,NA,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1182
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1182
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1183
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM13,Free State of Saxony,observed,NA,4
+2021-08-16,0 wk ahead inc death,2021-08-14,GM13,Free State of Saxony,observed,NA,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,point,NA,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.010,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.025,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.050,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.100,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.150,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.200,6
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.250,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.300,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.350,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.400,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.450,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.500,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.550,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.600,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.650,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.700,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.750,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.800,7
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.850,8
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.900,8
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.950,8
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.975,8
+2021-08-16,1 wk ahead inc death,2021-08-21,GM13,Free State of Saxony,quantile,0.990,9
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,point,NA,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.010,7
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.025,7
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.050,8
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.100,8
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.150,8
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.200,8
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.250,9
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.300,9
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.350,9
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.400,9
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.450,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.500,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.550,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.600,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.650,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.700,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.750,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.800,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.850,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.900,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.950,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.975,15
+2021-08-16,2 wk ahead inc death,2021-08-28,GM13,Free State of Saxony,quantile,0.990,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,point,NA,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.010,9
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.025,9
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.050,10
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.100,10
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.150,11
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.200,11
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.250,12
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.300,12
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.350,12
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.400,13
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.450,13
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.500,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.550,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.600,15
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.650,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.700,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.750,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.800,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.850,19
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.900,21
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.950,24
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.975,27
+2021-08-16,3 wk ahead inc death,2021-09-04,GM13,Free State of Saxony,quantile,0.990,31
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,point,NA,20
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.010,10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.025,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.050,12
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.100,13
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.150,14
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.200,15
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.250,15
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.300,16
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.350,17
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.400,18
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.450,19
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.500,20
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.550,21
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.600,22
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.650,23
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.700,24
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.750,26
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.800,28
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.850,31
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.900,34
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.950,41
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.975,48
+2021-08-16,4 wk ahead inc death,2021-09-11,GM13,Free State of Saxony,quantile,0.990,60
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM13,Free State of Saxony,observed,NA,10139
+2021-08-16,0 wk ahead cum death,2021-08-14,GM13,Free State of Saxony,observed,NA,10148
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,point,NA,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.010,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.025,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.050,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.100,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.150,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.200,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.250,10152
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.300,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.350,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.400,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.450,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.500,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.550,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.600,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.650,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.700,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.750,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.800,10153
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.850,10154
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.900,10154
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.950,10154
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.975,10154
+2021-08-16,1 wk ahead cum death,2021-08-21,GM13,Free State of Saxony,quantile,0.990,10155
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,point,NA,10163
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.010,10159
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.025,10159
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.050,10160
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.100,10160
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.150,10161
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.200,10161
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.250,10161
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.300,10162
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.350,10162
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.400,10162
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.450,10162
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.500,10163
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.550,10163
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.600,10163
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.650,10164
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.700,10164
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.750,10164
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.800,10165
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.850,10166
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.900,10166
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.950,10168
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.975,10169
+2021-08-16,2 wk ahead cum death,2021-08-28,GM13,Free State of Saxony,quantile,0.990,10171
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,point,NA,10177
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.010,10167
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.025,10168
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.050,10169
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.100,10170
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.150,10171
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.200,10172
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.250,10173
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.300,10174
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.350,10174
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.400,10175
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.450,10176
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.500,10177
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.550,10177
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.600,10178
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.650,10179
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.700,10180
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.750,10181
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.800,10183
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.850,10185
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.900,10187
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.950,10191
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.975,10196
+2021-08-16,3 wk ahead cum death,2021-09-04,GM13,Free State of Saxony,quantile,0.990,10202
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,point,NA,10196
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.010,10178
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.025,10180
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.050,10181
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.100,10183
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.150,10185
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.200,10187
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.250,10188
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.300,10190
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.350,10191
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.400,10193
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.450,10195
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.500,10196
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.550,10198
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.600,10200
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.650,10202
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.700,10205
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.750,10207
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.800,10211
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.850,10215
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.900,10221
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.950,10232
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.975,10244
+2021-08-16,4 wk ahead cum death,2021-09-11,GM13,Free State of Saxony,quantile,0.990,10262
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM14,Sachsen-Anhalt State,observed,NA,14
+2021-08-16,0 wk ahead inc death,2021-08-14,GM14,Sachsen-Anhalt State,observed,NA,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,point,NA,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.010,8
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.025,8
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.050,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.100,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.150,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.200,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.250,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.300,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.350,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.400,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.450,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.500,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.550,9
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.600,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.650,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.700,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.750,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.800,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.850,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.900,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.950,10
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.975,11
+2021-08-16,1 wk ahead inc death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.990,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,point,NA,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.010,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.025,10
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.050,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.100,11
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.150,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.200,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.250,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.300,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.350,12
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.400,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.450,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.500,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.550,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.600,13
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.650,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.700,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.750,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.800,14
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.850,15
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.900,15
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.950,16
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.975,17
+2021-08-16,2 wk ahead inc death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.990,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,point,NA,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.010,11
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.025,12
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.050,13
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.100,14
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.150,15
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.200,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.250,16
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.300,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.350,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.400,17
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.450,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.500,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.550,18
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.600,19
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.650,20
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.700,20
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.750,20
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.800,21
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.850,22
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.900,23
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.950,26
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.975,27
+2021-08-16,3 wk ahead inc death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.990,30
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,point,NA,25
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.010,13
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.025,14
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.050,16
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.100,18
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.150,20
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.200,21
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.250,21
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.300,22
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.350,23
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.400,24
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.450,24
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.500,25
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.550,26
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.600,27
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.650,28
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.700,29
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.750,30
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.800,31
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.850,33
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.900,35
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.950,40
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.975,44
+2021-08-16,4 wk ahead inc death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.990,49
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM14,Sachsen-Anhalt State,observed,NA,3468
+2021-08-16,0 wk ahead cum death,2021-08-14,GM14,Sachsen-Anhalt State,observed,NA,3470
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,point,NA,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.010,3479
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.025,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.050,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.100,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.150,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.200,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.250,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.300,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.350,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.400,3480
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.450,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.500,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.550,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.600,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.650,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.700,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.750,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.800,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.850,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.900,3481
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.950,3482
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.975,3482
+2021-08-16,1 wk ahead cum death,2021-08-21,GM14,Sachsen-Anhalt State,quantile,0.990,3482
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,point,NA,3494
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.010,3489
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.025,3490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.050,3490
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.100,3491
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.150,3492
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.200,3492
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.250,3492
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.300,3493
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.350,3493
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.400,3493
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.450,3493
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.500,3494
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.550,3494
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.600,3494
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.650,3494
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.700,3495
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.750,3495
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.800,3495
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.850,3496
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.900,3497
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.950,3498
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.975,3499
+2021-08-16,2 wk ahead cum death,2021-08-28,GM14,Sachsen-Anhalt State,quantile,0.990,3500
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,point,NA,3512
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.010,3500
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.025,3502
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.050,3503
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.100,3505
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.150,3507
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.200,3508
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.250,3509
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.300,3509
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.350,3510
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.400,3510
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.450,3511
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.500,3512
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.550,3512
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.600,3513
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.650,3514
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.700,3515
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.750,3516
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.800,3516
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.850,3518
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.900,3520
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.950,3523
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.975,3526
+2021-08-16,3 wk ahead cum death,2021-09-04,GM14,Sachsen-Anhalt State,quantile,0.990,3530
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,point,NA,3537
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.010,3513
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.025,3516
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.050,3519
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.100,3524
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.150,3526
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.200,3529
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.250,3530
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.300,3531
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.350,3533
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.400,3534
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.450,3535
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.500,3537
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.550,3538
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.600,3540
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.650,3542
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.700,3543
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.750,3545
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.800,3547
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.850,3550
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.900,3555
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.950,3563
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.975,3570
+2021-08-16,4 wk ahead cum death,2021-09-11,GM14,Sachsen-Anhalt State,quantile,0.990,3579
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM15,Free State of Thuringia,observed,NA,3
+2021-08-16,0 wk ahead inc death,2021-08-14,GM15,Free State of Thuringia,observed,NA,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,point,NA,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.010,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.025,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.050,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.100,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.150,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.200,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.250,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.300,4
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.350,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.400,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.450,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.500,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.550,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.600,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.650,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.700,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.750,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.800,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.850,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.900,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.950,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.975,5
+2021-08-16,1 wk ahead inc death,2021-08-21,GM15,Free State of Thuringia,quantile,0.990,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,point,NA,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.010,4
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.025,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.050,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.100,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.150,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.200,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.250,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.300,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.350,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.400,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.450,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.500,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.550,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.600,5
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.650,6
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.700,6
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.750,6
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.800,6
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.850,6
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.900,6
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.950,7
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.975,7
+2021-08-16,2 wk ahead inc death,2021-08-28,GM15,Free State of Thuringia,quantile,0.990,8
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,point,NA,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.010,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.025,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.050,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.100,5
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.150,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.200,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.250,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.300,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.350,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.400,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.450,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.500,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.550,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.600,6
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.650,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.700,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.750,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.800,7
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.850,8
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.900,8
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.950,9
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.975,10
+2021-08-16,3 wk ahead inc death,2021-09-04,GM15,Free State of Thuringia,quantile,0.990,11
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,point,NA,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.010,5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.025,5
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.050,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.100,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.150,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.200,6
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.250,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.300,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.350,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.400,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.450,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.500,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.550,7
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.600,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.650,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.700,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.750,8
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.800,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.850,9
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.900,10
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.950,12
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.975,13
+2021-08-16,4 wk ahead inc death,2021-09-11,GM15,Free State of Thuringia,quantile,0.990,16
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM15,Free State of Thuringia,observed,NA,4384
+2021-08-16,0 wk ahead cum death,2021-08-14,GM15,Free State of Thuringia,observed,NA,4389
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,point,NA,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.010,4393
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.025,4393
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.050,4393
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.100,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.150,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.200,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.250,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.300,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.350,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.400,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.450,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.500,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.550,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.600,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.650,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.700,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.750,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.800,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.850,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.900,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.950,4394
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.975,4395
+2021-08-16,1 wk ahead cum death,2021-08-21,GM15,Free State of Thuringia,quantile,0.990,4395
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,point,NA,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.010,4398
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.025,4398
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.050,4398
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.100,4398
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.150,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.200,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.250,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.300,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.350,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.400,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.450,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.500,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.550,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.600,4399
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.650,4400
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.700,4400
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.750,4400
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.800,4400
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.850,4400
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.900,4400
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.950,4401
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.975,4402
+2021-08-16,2 wk ahead cum death,2021-08-28,GM15,Free State of Thuringia,quantile,0.990,4402
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,point,NA,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.010,4403
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.025,4403
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.050,4403
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.100,4404
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.150,4404
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.200,4404
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.250,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.300,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.350,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.400,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.450,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.500,4405
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.550,4406
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.600,4406
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.650,4406
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.700,4406
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.750,4407
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.800,4407
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.850,4408
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.900,4408
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.950,4410
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.975,4411
+2021-08-16,3 wk ahead cum death,2021-09-04,GM15,Free State of Thuringia,quantile,0.990,4413
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,point,NA,4413
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.010,4408
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.025,4408
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.050,4409
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.100,4410
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.150,4410
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.200,4411
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.250,4411
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.300,4411
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.350,4412
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.400,4412
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.450,4412
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.500,4413
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.550,4413
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.600,4413
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.650,4414
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.700,4415
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.750,4415
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.800,4416
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.850,4417
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.900,4419
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.950,4422
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.975,4425
+2021-08-16,4 wk ahead cum death,2021-09-11,GM15,Free State of Thuringia,quantile,0.990,4429
+2021-08-16,-1 wk ahead inc death,2021-08-07,GM16,Berlin State,observed,NA,2
+2021-08-16,0 wk ahead inc death,2021-08-14,GM16,Berlin State,observed,NA,2
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,point,NA,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.010,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.025,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.050,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.100,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.150,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.200,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.250,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.300,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.350,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.400,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.450,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.500,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.550,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.600,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.650,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.700,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.750,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.800,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.850,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.900,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.950,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.975,0
+2021-08-16,1 wk ahead inc death,2021-08-21,GM16,Berlin State,quantile,0.990,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,point,NA,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.010,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.025,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.050,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.100,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.150,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.200,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.250,-1
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.300,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.350,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.400,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.450,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.500,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.550,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.600,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.650,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.700,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.750,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.800,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.850,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.900,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.950,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.975,0
+2021-08-16,2 wk ahead inc death,2021-08-28,GM16,Berlin State,quantile,0.990,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,point,NA,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.010,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.025,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.050,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.100,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.150,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.200,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.250,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.300,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.350,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.400,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.450,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.500,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.550,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.600,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.650,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.700,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.750,-1
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.800,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.850,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.900,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.950,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.975,0
+2021-08-16,3 wk ahead inc death,2021-09-04,GM16,Berlin State,quantile,0.990,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,point,NA,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.010,-3
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.025,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.050,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.100,-2
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.150,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.200,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.250,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.300,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.350,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.400,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.450,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.500,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.550,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.600,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.650,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.700,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.750,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.800,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.850,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.900,-1
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.950,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.975,0
+2021-08-16,4 wk ahead inc death,2021-09-11,GM16,Berlin State,quantile,0.990,0
+2021-08-16,-1 wk ahead cum death,2021-08-07,GM16,Berlin State,observed,NA,3585
+2021-08-16,0 wk ahead cum death,2021-08-14,GM16,Berlin State,observed,NA,3587
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,point,NA,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.010,3585
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.025,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.050,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.100,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.150,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.200,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.250,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.300,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.350,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.400,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.450,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.500,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.550,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.600,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.650,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.700,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.750,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.800,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.850,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.900,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.950,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.975,3586
+2021-08-16,1 wk ahead cum death,2021-08-21,GM16,Berlin State,quantile,0.990,3586
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,point,NA,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.010,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.025,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.050,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.100,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.150,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.200,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.250,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.300,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.350,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.400,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.450,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.500,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.550,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.600,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.650,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.700,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.750,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.800,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.850,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.900,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.950,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.975,3585
+2021-08-16,2 wk ahead cum death,2021-08-28,GM16,Berlin State,quantile,0.990,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,point,NA,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.010,3583
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.025,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.050,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.100,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.150,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.200,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.250,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.300,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.350,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.400,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.450,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.500,3584
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.550,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.600,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.650,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.700,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.750,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.800,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.850,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.900,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.950,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.975,3585
+2021-08-16,3 wk ahead cum death,2021-09-04,GM16,Berlin State,quantile,0.990,3585
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,point,NA,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.010,3581
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.025,3582
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.050,3582
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.100,3582
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.150,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.200,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.250,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.300,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.350,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.400,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.450,3583
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.500,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.550,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.600,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.650,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.700,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.750,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.800,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.850,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.900,3584
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.950,3585
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.975,3585
+2021-08-16,4 wk ahead cum death,2021-09-11,GM16,Berlin State,quantile,0.990,3585


### PR DESCRIPTION
Number of deaths in Bremen (< 0) don't make sense and need to be capped.