### PR TITLE
Predictions as of 7 February 2022

### DIFF
--- a/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger-case.csv
+++ b/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger-case.csv
@@ -1,3333 +1,3333 @@
 forecast_date,target,target_end_date,location,location_name,type,quantile,value
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM,Germany,observed,NA,968533
-2022-02-07,0 wk ahead inc case,2022-02-05,GM,Germany,observed,NA,1460338
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,point,NA,2013058
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.010,1730383
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.025,1771270
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.050,1800223
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.100,1836911
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.150,1861001
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.200,1884207
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.250,1908740
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.300,1929736
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.350,1951616
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.400,1967087
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.450,1992282
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.500,2013058
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.550,2034938
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.600,2062122
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.650,2084003
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.700,2109198
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.750,2143013
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.800,2178154
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.850,2228324
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.900,2286450
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.950,2379717
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.975,2477846
-2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.990,2617526
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,point,NA,2569682
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.010,2086304
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.025,2157472
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.050,2202251
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.100,2253827
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.150,2299806
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.200,2342186
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.250,2378570
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.300,2416152
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.350,2454934
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.400,2487320
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.450,2521704
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.500,2569682
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.550,2616460
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.600,2663238
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.650,2710017
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.700,2757595
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.750,2823964
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.800,2887135
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.850,2987889
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.900,3097039
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.950,3278155
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.975,3464869
-2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.990,3742341
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,point,NA,2994586
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.010,2359135
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.025,2443861
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.050,2506243
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.100,2577469
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.150,2631471
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.200,2693852
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.250,2736216
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.300,2786959
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.350,2839564
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.400,2880996
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.450,2928946
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.500,2994586
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.550,3059295
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.600,3120745
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.650,3183127
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.700,3245508
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.750,3326511
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.800,3416358
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.850,3538793
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.900,3687298
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.950,3913547
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.975,4120709
-2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.990,4429357
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,point,NA,3139223
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.010,2479073
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.025,2576503
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.050,2643185
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.100,2709496
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.150,2769139
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.200,2827671
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.250,2874348
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.300,2931768
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.350,2987337
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.400,3026605
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.450,3084766
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.500,3139223
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.550,3204423
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.600,3270364
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.650,3332600
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.700,3392984
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.750,3465593
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.800,3543018
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.850,3646745
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.900,3779738
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.950,3958297
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.975,4094624
-2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.990,4294299
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM,Germany,observed,NA,9429079
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM,Germany,observed,NA,1022238
+2022-02-07,0 wk ahead inc case,2022-02-05,GM,Germany,observed,NA,1271172
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,point,NA,1660179
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.010,1518513
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.025,1533373
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.050,1553611
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.100,1566914
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.150,1579793
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.200,1593238
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.250,1601022
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.300,1613759
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.350,1626071
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.400,1638384
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.450,1649281
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.500,1660179
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.550,1669378
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.600,1679709
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.650,1691738
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.700,1707872
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.750,1724147
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.800,1740847
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.850,1760661
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.900,1799580
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.950,1862982
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.975,1913789
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.990,1993467
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,point,NA,1955855
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.010,1735723
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.025,1758062
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.050,1779147
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.100,1802992
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.150,1829599
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.200,1846165
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.250,1863736
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.300,1879047
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.350,1893103
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.400,1911176
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.450,1937782
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.500,1955855
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.550,1974429
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.600,1984219
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.650,2010072
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.700,2034671
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.750,2064038
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.800,2095414
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.850,2134069
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.900,2200836
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.950,2325084
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.975,2417705
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.990,2567807
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,point,NA,2181105
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.010,1887360
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.025,1925589
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.050,1947808
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.100,1976562
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.150,2006296
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.200,2029495
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.250,2058248
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.300,2071972
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.350,2099419
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.400,2117063
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.450,2154966
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.500,2181105
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.550,2199077
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.600,2216394
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.650,2251029
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.700,2285991
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.750,2323567
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.800,2367351
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.850,2413423
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.900,2517002
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.950,2691485
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.975,2809441
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.990,3014311
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,point,NA,2283349
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.010,1954053
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.025,2004841
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.050,2027082
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.100,2055630
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.150,2089157
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.200,2117041
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.250,2144593
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.300,2161523
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.350,2186751
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.400,2215963
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.450,2253473
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.500,2283349
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.550,2302602
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.600,2324843
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.650,2366005
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.700,2403848
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.750,2446006
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.800,2494139
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.850,2550239
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.900,2657459
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.950,2850655
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.975,2979785
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.990,3180948
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM,Germany,observed,NA,9618245
 2022-02-07,0 wk ahead cum case,2022-02-05,GM,Germany,observed,NA,10889417
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,point,NA,13032834
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.010,12638791
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.025,12712590
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.050,12748950
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.100,12806589
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.150,12834870
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.200,12867460
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.250,12905706
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.300,12933986
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.350,12953917
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.400,12978158
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.450,13007516
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.500,13032834
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.550,13060576
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.600,13084547
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.650,13108788
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.700,13139223
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.750,13178008
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.800,13225411
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.850,13276586
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.900,13347691
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.950,13448155
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.975,13554544
-2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.990,13709145
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,point,NA,15603498
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.010,14733815
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.025,14858055
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.050,14951069
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.100,15065344
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.150,15141749
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.200,15211509
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.250,15282599
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.300,15350366
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.350,15417469
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.400,15460655
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.450,15540381
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.500,15603498
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.550,15665286
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.600,15750992
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.650,15819424
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.700,15886527
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.750,15991500
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.800,16102453
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.850,16256591
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.900,16434647
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.950,16714354
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.975,17013992
-2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.990,17433221
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,point,NA,18591421
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.010,17103992
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.025,17330658
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.050,17458088
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.100,17638519
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.150,17779481
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.200,17901272
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.250,18016297
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.300,18136960
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.350,18258751
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.400,18348967
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.450,18461736
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.500,18591421
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.550,18730127
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.600,18874472
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.650,19004157
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.700,19140608
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.750,19322167
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.800,19503726
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.850,19799182
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.900,20119447
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.950,20619016
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.975,21127606
-2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.990,21874140
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,point,NA,21740940
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.010,19583911
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.025,19909697
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.050,20101598
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.100,20345566
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.150,20556806
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.200,20745732
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.250,20894492
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.300,21068542
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.350,21229204
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.400,21370526
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.450,21544576
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.500,21740940
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.550,21934329
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.600,22132181
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.650,22334495
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.700,22538297
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.750,22773339
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.800,23050034
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.850,23466564
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.900,23906895
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.950,24594169
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.975,25227890
-2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.990,26133842
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM01,Baden-Württemberg State,observed,NA,120967
-2022-02-07,0 wk ahead inc case,2022-02-05,GM01,Baden-Württemberg State,observed,NA,195800
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,point,NA,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,1
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,1
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,2
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,2
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,4
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,4
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,6
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,6
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,7
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,7
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,8
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,8
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,9
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,9
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,9
-2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,9
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,point,NA,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,3
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,3
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,3
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,3
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,3
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,3
-2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,3
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,point,NA,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,1
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,point,NA,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,0
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM01,Baden-Württemberg State,observed,NA,1301970
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,point,NA,12676795
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.010,12461181
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.025,12494558
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.050,12522224
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.100,12546141
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.150,12560420
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.200,12585052
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.250,12601473
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.300,12613789
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.350,12626104
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.400,12643418
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.450,12661088
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.500,12676795
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.550,12690182
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.600,12703568
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.650,12724273
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.700,12737303
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.750,12761934
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.800,12779426
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.850,12811197
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.900,12855284
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.950,12924359
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.975,12988794
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.990,13074290
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,point,NA,14634999
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.010,14203707
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.025,14244660
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.050,14305238
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.100,14355576
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.150,14398663
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.200,14433217
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.250,14461373
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.300,14496781
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.350,14524936
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.400,14573995
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.450,14598312
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.500,14634999
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.550,14664008
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.600,14692163
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.650,14724158
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.700,14773644
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.750,14828249
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.800,14878161
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.850,14940444
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.900,15053493
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.950,15240770
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.975,15393920
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.990,15641774
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,point,NA,16808020
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.010,16099356
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.025,16165418
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.050,16263009
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.100,16325318
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.150,16404141
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.200,16452937
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.250,16507738
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.300,16569296
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.350,16633857
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.400,16682652
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.450,16763728
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.500,16808020
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.550,16871079
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.600,16910115
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.650,16967169
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.700,17061757
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.750,17145085
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.800,17241175
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.850,17353030
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.900,17563978
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.950,17925066
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.975,18200574
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.990,18655500
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,point,NA,19081670
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.010,18068758
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.025,18174360
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.050,18273496
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.100,18374787
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.150,18506250
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.200,18568749
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.250,18657109
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.300,18737926
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.350,18817666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.400,18886630
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.450,19007318
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.500,19081670
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.550,19171108
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.600,19233606
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.650,19334898
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.700,19464205
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.750,19599979
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.800,19730364
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.850,19924326
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.900,20207725
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.950,20790688
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.975,21186155
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.990,21841315
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM01,Baden-Württemberg State,observed,NA,128954
+2022-02-07,0 wk ahead inc case,2022-02-05,GM01,Baden-Württemberg State,observed,NA,170506
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,point,NA,248763
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,192443
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,202747
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,210394
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,219803
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,226230
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,230134
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,234012
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,237510
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,240384
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,243448
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,245943
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,248763
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,251475
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,254891
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,258525
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,261236
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,265710
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,269154
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,274686
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,281383
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,292392
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,302452
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,313054
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,point,NA,314773
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,219432
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,236912
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,250056
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,265893
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,276482
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,283510
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,290082
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,295605
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,300579
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,306969
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,310072
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,314773
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,320341
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,325133
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,331158
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,336133
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,343709
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,350418
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,359226
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,369815
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,387477
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,402036
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,419197
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,point,NA,351492
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,234918
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,256991
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,273758
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,292966
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,306549
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,314880
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,322043
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,328516
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,335096
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,342312
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,346981
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,351492
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,356055
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,360777
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,367569
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,373724
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,381842
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,388422
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,397919
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,408001
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,424184
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,440898
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,462069
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,point,NA,336818
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,235408
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,257201
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,274034
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,290367
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,303561
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,309339
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,315571
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,319802
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,323715
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,328492
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,332223
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,336818
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,340503
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,345416
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,349921
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,356972
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,363569
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,370439
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,379129
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,390821
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,407154
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,420620
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,437909
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM01,Baden-Württemberg State,observed,NA,1327264
 2022-02-07,0 wk ahead cum case,2022-02-05,GM01,Baden-Württemberg State,observed,NA,1497770
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,point,NA,960070
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,960033
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,960034
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,960036
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,960040
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,960044
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,960047
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,960051
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,960055
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,960059
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,960062
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,960066
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,960070
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,960074
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,960077
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,960081
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,960085
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,960089
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,960093
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,960096
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,960100
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,960104
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,960106
-2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,960107
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,point,NA,960072
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,960033
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,960034
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,960036
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,960040
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,960044
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,960048
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,960052
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,960056
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,960060
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,960064
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,960068
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,960072
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,960076
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,960080
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,960084
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,960087
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,960091
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,960095
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,960099
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,960103
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,960107
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,960109
-2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,960110
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,point,NA,960072
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,960033
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,960035
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,960037
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,960040
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,960044
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,960048
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,960052
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,960056
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,960060
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,960064
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,960068
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,960072
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,960076
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,960080
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,960084
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,960088
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,960092
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,960096
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,960100
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,960104
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,960108
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,960110
-2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,960112
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,point,NA,960073
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,960033
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,960035
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,960037
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,960041
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,960044
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,960049
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,960053
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,960056
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,960061
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,960065
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,960069
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,960073
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,960077
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,960081
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,960085
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,960089
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,960093
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,960097
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,960101
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,960105
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,960109
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,960111
-2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,960112
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM02,Free State of Bavaria,observed,NA,169759
-2022-02-07,0 wk ahead inc case,2022-02-05,GM02,Free State of Bavaria,observed,NA,277046
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,point,NA,415267
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,311904
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,325624
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,339878
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,357622
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,368094
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,376870
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,385305
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,391269
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,397571
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,404068
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,409789
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,415267
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,421376
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,427436
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,432527
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,439750
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,448865
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,458222
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,466512
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,478681
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,499189
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,520376
-2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,545150
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,point,NA,565284
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,372306
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,396854
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,423499
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,455996
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,475128
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,491727
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,507539
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,519070
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,531475
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,542832
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,553490
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,565284
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,575767
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,587560
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,597782
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,611148
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,626872
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,642772
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,660506
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,684180
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,719911
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,755466
-2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,796613
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,point,NA,670162
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,417165
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,450950
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,485914
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,530503
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,556333
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,576565
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,596699
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,614181
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,628913
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,641484
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,657591
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,670162
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,681751
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,694028
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,709939
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,725653
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,741072
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,757474
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,777804
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,801866
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,835259
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,868848
-2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,914124
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,point,NA,675011
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,436397
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,473974
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,510954
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,556526
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,582001
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,601425
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,620027
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,636537
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,647295
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,655961
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,664777
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,675011
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,684275
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,693091
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,702877
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,712888
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,723721
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,736869
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,753006
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,769591
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,806123
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,829506
-2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,860211
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM02,Free State of Bavaria,observed,NA,1699836
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,point,NA,1764916
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,1699150
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,1711465
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,1720631
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,1731498
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,1738207
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,1743530
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,1748349
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,1752097
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,1755026
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,1758460
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,1761704
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,1764916
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,1768570
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,1771625
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,1776350
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,1779846
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,1783626
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,1789390
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,1794776
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,1802556
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,1815722
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,1826683
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,1839187
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,point,NA,2079853
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,1918941
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,1948605
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,1970454
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,1997311
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,2015063
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,2027354
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,2038582
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,2047838
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,2055879
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,2064832
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,2072798
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,2079853
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,2087667
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,2098061
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,2108000
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,2116421
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,2127649
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,2139029
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,2154278
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,2172107
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,2202377
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,2228172
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,2256849
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,point,NA,2431979
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,2153884
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,2205842
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,2244649
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,2291191
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,2322649
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,2341988
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,2362230
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,2377185
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,2389433
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,2407999
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,2419473
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,2431979
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,2443840
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,2457120
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,2475427
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,2490125
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,2509464
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,2532413
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,2553170
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,2578827
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,2624209
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,2660179
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,2711492
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,point,NA,2775244
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,2389972
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,2463855
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,2519790
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,2583392
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,2628349
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,2655184
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,2679231
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,2699444
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,2718612
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,2742833
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,2760084
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,2775244
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,2788835
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,2803995
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,2824906
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,2848604
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,2871083
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,2898092
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,2926495
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,2957686
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,3008568
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,3063631
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,3134726
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM02,Free State of Bavaria,observed,NA,181775
+2022-02-07,0 wk ahead inc case,2022-02-05,GM02,Free State of Bavaria,observed,NA,244521
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,point,NA,343270
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,312634
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,319313
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,320653
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,324676
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,329685
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,331506
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,333732
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,335326
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,336439
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,339424
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,341752
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,343270
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,344762
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,346963
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,348684
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,350682
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,353136
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,357082
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,361484
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,367100
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,377802
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,387541
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,402442
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,point,NA,427331
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,377401
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,387516
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,390981
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,397863
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,405946
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,407147
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,411719
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,414398
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,417262
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,421050
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,425345
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,427331
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,430795
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,434398
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,436708
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,440772
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,447239
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,453936
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,462158
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,472689
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,492411
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,511487
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,540170
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,point,NA,491863
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,427242
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,439590
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,444294
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,453996
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,462875
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,466167
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,470930
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,475458
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,480867
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,483984
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,489511
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,491863
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,497037
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,501624
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,505034
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,510209
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,520499
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,528084
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,539667
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,553721
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,582121
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,606111
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,640392
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,point,NA,519233
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,450219
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,462956
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,469191
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,478837
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,487470
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,492160
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,496956
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,501913
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,506229
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,510279
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,514703
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,519233
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,522856
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,528079
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,532716
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,538631
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,546732
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,556537
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,568688
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,583397
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,610363
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,633332
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,665574
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM02,Free State of Bavaria,observed,NA,1732361
 2022-02-07,0 wk ahead cum case,2022-02-05,GM02,Free State of Bavaria,observed,NA,1976882
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,point,NA,2417123
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,2295996
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,2314262
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,2330702
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,2351308
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,2363695
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,2374997
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,2384130
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,2390466
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,2396916
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,2405307
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,2411187
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,2417123
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,2424030
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,2430823
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,2436017
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,2444408
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,2455025
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,2465186
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,2476374
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,2488703
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,2510965
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,2535225
-2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,2561996
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,point,NA,2982857
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,2671858
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,2712787
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,2754003
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,2807902
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,2840040
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,2866989
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,2890912
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,2910512
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,2928670
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,2947838
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,2965852
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,2982857
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,2998854
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,3018021
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,3033586
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,3055491
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,3081144
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,3108093
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,3135187
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,3170927
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,3230879
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,3290542
-2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,3356547
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,point,NA,3654293
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,3087646
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,3163006
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,3242955
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,3338121
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,3394882
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,3443431
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,3487874
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,3524105
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,3556471
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,3589561
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,3622652
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,3654293
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,3681346
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,3712746
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,3745112
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,3781101
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,3822887
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,3867330
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,3915154
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,3973365
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,4069738
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,4154518
-2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,4258138
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,point,NA,4333150
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,3523894
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,3635732
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,3751654
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,3895536
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,3979415
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,4044758
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,4107903
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,4161623
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,4205604
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,4247073
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,4293567
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,4333150
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,4369592
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,4408861
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,4460068
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,4504049
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,4550858
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,4606463
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,4661754
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,4738407
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,4843962
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,4943549
-2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,5087430
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,11019
-2022-02-07,0 wk ahead inc case,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,10699
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,10595
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,9102
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,9433
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,9557
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,9781
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,9919
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,10003
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,10064
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,10156
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,10296
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,10377
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,10489
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,10595
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,10671
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,10796
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,10897
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,11028
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,11156
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,11337
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,11579
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,11940
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,12488
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,13024
-2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,13748
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,9986
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,7991
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,8432
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,8615
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,8875
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,9018
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,9166
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,9228
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,9381
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,9549
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,9663
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,9830
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,9986
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,10110
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,10237
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,10391
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,10574
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,10778
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,11005
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,11406
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,11957
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,12845
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,13742
-2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,14979
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,9275
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,6968
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,7462
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,7645
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,7965
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,8126
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,8270
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,8343
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,8548
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,8741
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,8861
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,9061
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,9275
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,9397
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,9546
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,9697
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,9960
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,10215
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,10493
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,11030
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,11715
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,12884
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,14035
-2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,15725
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,8445
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,6038
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,6540
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,6712
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,7056
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,7255
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,7368
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,7477
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,7691
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,7878
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,8024
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,8249
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,8445
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,8599
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,8768
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,8932
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,9240
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,9499
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,9837
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,10472
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,11220
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,12597
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,13933
-2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,15862
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,83082
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,point,NA,2348192
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,2304044
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,2311660
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,2317127
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,2322468
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,2328314
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,2332865
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,2334635
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,2335962
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,2338269
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,2341461
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,2345664
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,2348192
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,2350467
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,2352711
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,2355524
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,2358178
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,2360517
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,2363772
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,2368797
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,2376539
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,2388485
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,2399735
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,2417306
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,point,NA,2776506
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,2681877
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,2701020
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,2707685
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,2717760
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,2734578
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,2741398
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,2746358
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,2750311
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,2754728
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,2763409
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,2771159
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,2776506
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,2781001
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,2786892
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,2792472
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,2798982
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,2805880
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,2818512
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,2830603
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,2847420
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,2881366
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,2909732
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,2955070
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,point,NA,3267751
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,3109127
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,3144226
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,3149531
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,3171162
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,3196874
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,3205444
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,3218640
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,3228027
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,3234013
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,3249929
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,3259044
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,3267751
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,3276593
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,3288429
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,3295367
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,3309243
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,3325024
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,3344478
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,3369509
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,3400663
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,3460656
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,3513576
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,3597513
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,point,NA,3785999
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,3559367
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,3607079
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,3618628
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,3651194
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,3688682
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,3695498
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,3715756
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,3730335
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,3740748
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,3758924
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,3775964
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,3785999
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,3801903
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,3816103
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,3827084
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,3846775
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,3874986
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,3901303
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,3935951
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,3983095
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,4071135
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,4149140
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,4261793
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM03,Free Hanseatic City of Bremen,observed,NA,10805
+2022-02-07,0 wk ahead inc case,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,8917
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,6680
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,5257
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,5464
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,5640
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,5862
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,6020
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,6142
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,6239
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,6347
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,6416
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,6515
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,6583
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,6680
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,6774
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,6878
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,6983
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,7103
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,7224
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,7364
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,7545
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,7771
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,8174
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,8554
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,8988
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,5046
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,3492
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,3716
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,3891
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,4129
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,4299
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,4429
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,4544
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,4655
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,4758
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,4860
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,4943
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,5046
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,5161
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,5286
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,5418
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,5560
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,5701
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,5892
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,6108
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,6422
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,6944
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,7465
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,8070
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,3798
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,2330
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,2533
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,2695
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,2914
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,3065
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,3192
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,3299
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,3418
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,3514
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,3612
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,3703
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,3798
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,3919
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,4045
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,4180
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,4328
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,4477
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,4674
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,4929
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,5280
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,5848
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,6439
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,7148
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,2852
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,1555
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,1724
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,1862
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,2055
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,2185
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,2296
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,2395
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,2502
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,2588
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,2687
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,2765
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,2852
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,2971
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,3088
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,3219
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,3365
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,3495
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,3696
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,3955
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,4304
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,4895
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,5515
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,6264
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM03,Free Hanseatic City of Bremen,observed,NA,84864
 2022-02-07,0 wk ahead cum case,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,93781
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,105287
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,102837
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,103345
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,103707
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,103975
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,104288
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,104493
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,104617
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,104732
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,104853
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,104993
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,105131
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,105287
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,105417
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,105614
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,105755
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,105949
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,106124
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,106349
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,106659
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,107078
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,107778
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,108387
-2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,109296
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,115319
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,110938
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,111796
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,112338
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,112906
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,113372
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,113643
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,113882
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,114120
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,114421
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,114663
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,114978
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,115319
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,115524
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,115784
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,116202
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,116492
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,116873
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,117350
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,118017
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,119025
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,120587
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,122024
-2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,124121
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,124578
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,118050
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,119373
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,119998
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,120996
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,121502
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,121976
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,122226
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,122581
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,123187
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,123474
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,123985
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,124578
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,124928
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,125377
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,125920
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,126444
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,127081
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,127817
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,128953
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,130726
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,133459
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,136080
-2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,139775
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,133012
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,124088
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,126014
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,126684
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,128023
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,128683
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,129334
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,129637
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,130260
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,131022
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,131554
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,132214
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,133012
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,133590
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,134131
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,134855
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,135681
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,136552
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,137616
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,139395
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,141945
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,145971
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,149997
-2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,155720
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,40461
-2022-02-07,0 wk ahead inc case,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,44630
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,49462
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,33527
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,35858
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,37838
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,40221
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,41845
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,43319
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,44414
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,45523
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,46670
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,47616
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,48502
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,49462
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,50564
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,51443
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,52352
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,53387
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,54451
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,55792
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,57348
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,59671
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,62896
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,66090
-2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,70163
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,53368
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,29572
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,32639
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,35432
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,39055
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,41458
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,43672
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,45412
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,47046
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,48869
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,50278
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,51734
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,53368
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,55025
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,56481
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,57926
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,59690
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,61418
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,63703
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,66142
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,70048
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,75648
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,80632
-2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,87332
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,54806
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,25638
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,29150
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,32606
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,36829
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,39867
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,42584
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,44731
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,46737
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,49023
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,50834
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,52590
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,54806
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,56799
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,58694
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,60450
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,62596
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,64882
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,67822
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,70819
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,75334
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,82121
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,87862
-2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,95081
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,53534
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,21944
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,25578
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,29278
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,33887
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,37219
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,40182
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,42446
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,44790
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,47134
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,49136
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,51085
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,53534
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,55654
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,57511
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,59434
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,61712
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,63871
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,66808
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,69981
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,74195
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,80279
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,85520
-2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,91511
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,233883
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,100995
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,98959
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,99260
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,99549
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,99875
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,100103
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,100257
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,100401
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,100519
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,100626
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,100779
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,100884
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,100995
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,101128
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,101266
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,101398
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,101566
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,101711
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,101910
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,102129
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,102405
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,102918
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,103357
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,103916
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,106050
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,102467
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,102991
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,103474
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,104034
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,104415
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,104704
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,104970
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,105198
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,105403
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,105611
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,105853
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,106050
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,106277
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,106567
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,106823
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,107096
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,107413
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,107781
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,108205
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,108784
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,109823
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,110783
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,111913
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,109858
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,104844
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,105554
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,106202
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,106963
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,107525
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,107897
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,108290
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,108628
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,108924
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,109228
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,109531
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,109858
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,110196
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,110623
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,111003
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,111402
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,111923
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,112436
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,113157
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,114049
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,115662
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,117240
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,119060
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,112732
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,106406
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,107283
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,108055
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,109017
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,109728
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,110197
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,110685
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,111159
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,111505
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,111917
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,112310
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,112732
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,113173
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,113703
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,114243
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,114769
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,115414
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,116144
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,117058
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,118323
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,120564
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,122716
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,125326
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM04,Free Hanseatic City of Hamburg,observed,NA,41392
+2022-02-07,0 wk ahead inc case,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,37169
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,37118
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,30085
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,31186
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,32005
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,32996
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,33570
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,34055
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,34650
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,35115
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,35584
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,36043
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,36508
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,37118
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,37702
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,38339
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,38949
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,39675
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,40416
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,41381
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,42539
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,43943
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,46494
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,48628
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,51696
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,35341
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,26008
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,27349
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,28217
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,29464
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,30339
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,30970
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,31791
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,32383
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,33124
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,33739
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,34489
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,35341
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,36130
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,37179
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,38015
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,39191
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,40193
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,41802
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,43490
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,45612
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,49857
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,53430
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,58487
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,32939
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,22190
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,23633
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,24573
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,25912
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,26938
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,27669
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,28637
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,29321
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,30242
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,30954
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,31847
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,32939
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,33869
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,35113
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,36129
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,37563
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,38902
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,40877
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,43071
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,45720
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,51199
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,55757
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,62309
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,30011
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,18701
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,20230
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,21144
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,22474
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,23566
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,24351
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,25324
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,26089
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,27081
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,27856
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,28829
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,30011
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,31073
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,32384
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,33555
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,35114
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,36594
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,38768
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,41251
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,44160
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,50237
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,55063
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,62222
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM04,Free Hanseatic City of Hamburg,observed,NA,241344
 2022-02-07,0 wk ahead cum case,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,278513
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,332344
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,312477
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,315658
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,318206
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,321062
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,323099
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,324754
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,326298
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,327600
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,328921
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,330149
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,331209
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,332344
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,333497
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,334567
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,335850
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,336966
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,338110
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,339738
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,341617
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,344240
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,348155
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,351876
-2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,356452
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,385592
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,342305
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,348552
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,353876
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,360312
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,364630
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,368571
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,371820
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,374859
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,377731
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,380456
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,383035
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,385592
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,388611
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,391021
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,393620
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,396450
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,399469
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,403368
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,407686
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,414247
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,423491
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,432400
-2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,443552
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,440210
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,368291
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,378052
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,386663
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,397261
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,404547
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,411415
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,416539
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,421699
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,427067
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,431495
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,435574
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,440210
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,445509
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,449692
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,454050
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,459175
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,464474
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,470993
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,478418
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,489679
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,505436
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,520217
-2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,538798
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,493828
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,390281
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,403763
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,416049
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,431442
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,441481
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,451520
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,458883
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,466340
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,474372
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,480347
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,486658
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,493828
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,501143
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,507357
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,513237
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,520743
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,528344
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,537714
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,548279
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,563625
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,586332
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,605407
-2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,628831
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM05,Hesse State,observed,NA,84215
-2022-02-07,0 wk ahead inc case,2022-02-05,GM05,Hesse State,observed,NA,124253
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,point,NA,174011
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.010,148832
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.025,152397
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.050,156023
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.100,159208
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.150,161251
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.200,162894
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.250,165458
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.300,167821
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.350,169544
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.400,170826
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.450,172629
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.500,174011
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.550,175994
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.600,178138
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.650,180401
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.700,182524
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.750,185890
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.800,188974
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.850,192921
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.900,199391
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.950,207884
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.975,216778
-2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.990,229077
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,point,NA,225662
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.010,182149
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.025,187212
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.050,193569
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.100,198480
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.150,202059
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.200,205561
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.250,209825
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.300,213784
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.350,216830
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.400,219419
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.450,222845
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.500,225662
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.550,229621
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.600,233200
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.650,238301
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.700,242603
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.750,249151
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.800,255090
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.850,263008
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.900,276333
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.950,294339
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.975,311623
-2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.990,336825
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,point,NA,270817
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.010,210733
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.025,216942
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.050,226303
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.100,231605
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.150,237336
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.200,241873
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.250,247939
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.300,253670
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.350,257682
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.400,262076
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.450,266948
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.500,270817
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.550,276070
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.600,280655
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.650,288393
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.700,295652
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.750,303628
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.800,312560
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.850,322780
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.900,341646
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.950,366147
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.975,389216
-2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.990,420356
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,point,NA,296249
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.010,228847
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.025,235942
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.050,245553
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.100,251699
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.150,258546
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.200,263538
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.250,270921
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.300,276614
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.350,281605
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.400,286720
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.450,291876
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.500,296249
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.550,301364
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.600,306891
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.650,315223
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.700,323102
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.750,330775
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.800,340633
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.850,351317
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.900,368518
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.950,390545
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.975,409974
-2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.990,431300
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM05,Hesse State,observed,NA,672879
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,319623
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,309199
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,310932
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,312516
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,313791
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,314822
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,315523
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,316434
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,317081
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,317721
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,318335
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,318861
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,319623
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,320351
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,321201
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,321888
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,322731
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,323608
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,324761
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,326217
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,328017
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,330849
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,333607
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,337032
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,354939
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,335339
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,338424
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,341028
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,343458
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,345059
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,346732
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,348158
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,349555
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,350879
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,352131
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,353324
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,354939
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,356467
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,358300
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,359843
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,361749
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,363742
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,366391
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,369621
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,373666
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,380578
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,386529
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,395318
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,387736
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,357637
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,362019
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,365543
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,369686
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,372234
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,374306
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,376878
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,378973
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,380973
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,383045
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,385045
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,387736
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,390284
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,393284
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,396047
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,399357
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,402786
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,407334
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,412596
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,419359
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,431479
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,442219
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,457316
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,417802
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,376091
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,382107
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,386719
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,392334
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,395810
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,398785
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,402327
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,405001
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,408276
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,410984
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,414058
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,417802
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,421344
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,425689
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,429566
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,434713
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,439091
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,446177
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,453597
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,463189
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,481638
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,497279
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,519538
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM05,Hesse State,observed,NA,88454
+2022-02-07,0 wk ahead inc case,2022-02-05,GM05,Hesse State,observed,NA,109139
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,point,NA,132716
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.010,107902
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.025,110618
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.050,114022
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.100,117215
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.150,119732
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.200,122104
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.250,123813
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.300,125774
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.350,127430
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.400,129139
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.450,131338
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.500,132716
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.550,134676
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.600,136306
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.650,138015
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.700,139181
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.750,141300
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.800,143261
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.850,145593
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.900,149090
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.950,154575
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.975,159702
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.990,166459
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,point,NA,155179
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.010,113020
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.025,117202
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.050,122407
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.100,127730
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.150,131960
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.200,136262
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.250,139209
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.300,142797
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.350,145673
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.400,148857
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.450,152493
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.500,155179
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.550,158672
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.600,161405
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.650,164566
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.700,166610
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.750,170080
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.800,174405
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.850,178706
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.900,185432
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.950,195199
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.975,205371
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.990,218251
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,point,NA,173144
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.010,115144
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.025,120740
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.050,127513
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.100,134891
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.150,141028
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.200,146783
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.250,151076
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.300,155814
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.350,160011
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.400,164113
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.450,169487
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.500,173144
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.550,178263
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.600,182492
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.650,186658
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.700,189456
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.750,194576
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.800,200458
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.850,206564
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.900,216039
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.950,230253
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.975,244785
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.990,262337
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,point,NA,183757
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.010,114721
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.025,120681
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.050,129089
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.100,137780
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.150,145337
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.200,152254
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.250,157434
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.300,163075
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.350,168254
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.400,173363
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.450,179429
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.500,183757
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.550,190107
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.600,195145
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.650,199757
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.700,203446
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.750,209690
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.800,216501
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.850,223277
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.900,234097
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.950,249636
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.975,266948
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.990,285857
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM05,Hesse State,observed,NA,687993
 2022-02-07,0 wk ahead cum case,2022-02-05,GM05,Hesse State,observed,NA,797132
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,point,NA,983109
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.010,948555
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.025,954314
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.050,958736
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.100,963742
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.150,966925
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.200,969185
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.250,972028
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.300,975430
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.350,977326
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.400,979367
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.450,981238
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.500,983109
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.550,985758
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.600,988577
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.650,990642
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.700,993169
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.750,996693
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.800,1000557
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.850,1005101
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.900,1012415
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.950,1021430
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.975,1031928
-2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.990,1045390
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,point,NA,1208457
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.010,1130285
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.025,1141859
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.050,1152443
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.100,1162717
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.150,1169649
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.200,1174787
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.250,1182400
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.300,1189455
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.350,1194593
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.400,1199358
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.450,1204557
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.500,1208457
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.550,1214770
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.600,1221454
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.650,1228696
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.700,1235752
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.750,1245717
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.800,1255558
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.850,1267627
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.900,1288114
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.950,1315099
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.975,1342766
-2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.990,1381264
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,point,NA,1479846
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.010,1341643
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.025,1357606
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.050,1378599
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.100,1396421
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.150,1407027
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.200,1416977
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.250,1430972
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.300,1442452
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.350,1453495
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.400,1460712
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.450,1470224
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.500,1479846
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.550,1491545
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.600,1502260
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.650,1517021
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.700,1529048
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.750,1549822
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.800,1566769
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.850,1591589
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.900,1629420
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.950,1681902
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.975,1731323
-2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.990,1799440
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,point,NA,1775069
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.010,1570051
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.025,1595171
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.050,1624351
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.100,1648569
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.150,1665716
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.200,1681660
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.250,1701666
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.300,1719415
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.350,1734306
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.400,1746941
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.450,1762434
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.500,1775069
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.550,1794022
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.600,1808612
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.650,1831927
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.700,1851782
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.750,1879609
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.800,1907436
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.850,1942182
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.900,1999792
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.950,2073045
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.975,2141184
-2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.990,2233088
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM06,Lower Saxony State,observed,NA,72954
-2022-02-07,0 wk ahead inc case,2022-02-05,GM06,Lower Saxony State,observed,NA,111817
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,point,NA,147298
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.010,103901
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.025,111533
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.050,117355
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.100,124259
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.150,128750
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.200,132181
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.250,134843
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.300,137671
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.350,140416
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.400,143389
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.450,145406
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.500,147298
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.550,149399
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.600,151852
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.650,154202
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.700,156781
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.750,160357
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.800,163331
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.850,167573
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.900,172355
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.950,181214
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.975,188783
-2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.990,198618
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,point,NA,188752
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.010,110034
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.025,122832
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.050,133110
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.100,146144
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.150,153823
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.200,160439
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.250,165321
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.300,170204
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.350,175757
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.400,181230
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.450,185286
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.500,188752
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.550,192965
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.600,197809
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.650,202219
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.700,207732
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.750,213836
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.800,220215
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.850,227382
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.900,237778
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.950,255104
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.975,270265
-2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.990,289127
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,point,NA,223804
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.010,113204
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.025,130711
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.050,145126
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.100,163629
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.150,174270
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.200,184124
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.250,191306
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.300,198330
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.350,205511
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.400,212692
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.450,218825
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.500,223804
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.550,230723
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.600,236070
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.650,242570
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.700,250432
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.750,258452
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.800,268149
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.850,278056
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.900,291528
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.950,314119
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.975,334038
-2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.990,356840
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,point,NA,244513
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.010,113074
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.025,134649
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.050,152195
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.100,173718
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.150,186725
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.200,198048
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.250,206872
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.300,214981
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.350,224621
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.400,230283
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.450,237780
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.500,244513
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.550,250481
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.600,257111
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.650,263436
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.700,271596
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.750,280369
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.800,289295
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.850,299445
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.900,312808
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.950,332037
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.975,351827
-2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.990,376717
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM06,Lower Saxony State,observed,NA,616518
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,point,NA,940641
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.010,909348
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.025,913410
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.050,917732
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.100,922037
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.150,925027
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.200,927448
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.250,929820
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.300,931949
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.350,933850
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.400,936206
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.450,938692
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.500,940641
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.550,942380
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.600,944297
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.650,946149
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.700,948327
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.750,950260
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.800,952421
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.850,955411
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.900,958969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.950,965582
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.975,971220
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.990,978629
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,point,NA,1095819
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.010,1023065
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.025,1030599
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.050,1040486
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.100,1050054
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.150,1056950
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.200,1064286
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.250,1069309
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.300,1074730
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.350,1079714
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.400,1085016
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.450,1091394
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.500,1095819
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.550,1101121
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.600,1105786
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.650,1110450
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.700,1114357
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.750,1120655
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.800,1126157
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.850,1133771
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.900,1143698
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.950,1160441
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.975,1176228
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.990,1196559
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,point,NA,1268307
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.010,1138150
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.025,1151877
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.050,1169018
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.100,1184950
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.150,1198250
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.200,1210555
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.250,1220370
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.300,1230896
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.350,1239502
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.400,1249531
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.450,1260839
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.500,1268307
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.550,1278905
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.600,1288222
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.650,1297682
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.700,1303798
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.750,1314751
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.800,1326202
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.850,1339716
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.900,1359986
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.950,1390285
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.975,1419944
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.990,1458707
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,point,NA,1453223
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.010,1253008
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.025,1273680
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.050,1297920
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.100,1322999
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.150,1343461
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.200,1363084
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.250,1376621
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.300,1394669
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.350,1408101
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.400,1423002
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.450,1440106
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.500,1453223
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.550,1469802
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.600,1482290
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.650,1497505
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.700,1507369
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.750,1523949
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.800,1542942
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.850,1563824
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.900,1594360
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.950,1639586
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.975,1686807
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.990,1743786
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM06,Lower Saxony State,observed,NA,77736
+2022-02-07,0 wk ahead inc case,2022-02-05,GM06,Lower Saxony State,observed,NA,96573
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,point,NA,124166
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.010,110778
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.025,112431
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.050,114161
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.100,115792
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.150,117333
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.200,118365
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.250,119607
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.300,120450
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.350,121360
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.400,122269
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.450,123057
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.500,124166
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.550,125142
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.600,126207
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.650,127683
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.700,129147
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.750,129957
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.800,131132
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.850,133184
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.900,136246
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.950,141004
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.975,145453
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.990,151587
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,point,NA,149674
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.010,127038
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.025,129777
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.050,132793
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.100,135296
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.150,138228
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.200,139875
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.250,141779
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.300,143020
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.350,145181
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.400,146465
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.450,148112
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.500,149674
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.550,152477
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.600,153653
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.650,156520
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.700,159216
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.750,161227
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.800,163303
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.850,166854
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.900,173294
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.950,183136
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.975,191801
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.990,204638
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,point,NA,173742
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.010,141273
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.025,145232
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.050,149835
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.100,152505
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.150,157016
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.200,159594
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.250,162019
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.300,163400
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.350,166499
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.400,168709
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.450,171133
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.500,173742
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.550,177209
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.600,179235
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.650,183470
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.700,187459
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.750,190804
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.800,194027
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.850,199643
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.900,208849
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.950,223948
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.975,237359
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.990,257061
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,point,NA,192397
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.010,151986
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.025,156524
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.050,162348
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.100,165456
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.150,171387
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.200,174532
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.250,177533
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.300,179069
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.350,182642
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.400,186180
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.450,188609
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.500,192397
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.550,196827
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.600,199828
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.650,204616
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.700,209404
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.750,214263
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.800,218301
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.850,225089
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.900,236451
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.950,255031
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.975,271752
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.990,295084
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM06,Lower Saxony State,observed,NA,631762
 2022-02-07,0 wk ahead cum case,2022-02-05,GM06,Lower Saxony State,observed,NA,728335
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,point,NA,883428
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.010,832829
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.025,842022
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.050,848695
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.100,856640
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.150,862257
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.200,866073
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.250,869338
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.300,872338
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.350,875315
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.400,878507
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.450,881459
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.500,883428
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.550,885876
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.600,888564
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.650,891373
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.700,894325
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.750,897782
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.800,901862
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.850,906495
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.900,912016
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.950,921329
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.975,930018
-2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.990,941156
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,point,NA,1071827
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.010,943454
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.025,965499
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.050,982016
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.100,1002930
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.150,1016182
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.200,1026230
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.250,1034898
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.300,1043313
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.350,1051227
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.400,1060710
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.450,1066802
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.500,1071827
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.550,1078609
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.600,1085958
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.650,1093934
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.700,1101533
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.750,1110703
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.800,1122007
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.850,1134505
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.900,1149579
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.950,1176019
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.975,1199257
-2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.990,1228649
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,point,NA,1295099
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.010,1057627
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.025,1097148
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.050,1127221
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.100,1166627
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.150,1190593
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.200,1210987
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.250,1226197
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.300,1241291
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.350,1257307
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.400,1274475
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.450,1285651
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.500,1295099
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.550,1309041
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.600,1322753
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.650,1336695
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.700,1352941
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.750,1369878
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.800,1390503
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.850,1411358
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.900,1440164
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.950,1489479
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.975,1533494
-2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.990,1584767
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,point,NA,1537559
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.010,1171030
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.025,1231536
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.050,1280075
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.100,1341412
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.150,1376818
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.200,1409066
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.250,1434333
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.300,1456607
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.350,1479713
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.400,1505311
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.450,1524095
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.500,1537559
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.550,1561164
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.600,1576456
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.650,1598398
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.700,1624496
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.750,1649430
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.800,1681013
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.850,1710435
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.900,1754485
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.950,1822305
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.975,1882313
-2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.990,1954123
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,219290
-2022-02-07,0 wk ahead inc case,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,344417
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,267497
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,193630
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,206705
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,219222
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,229458
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,236159
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,244953
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,248140
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,252119
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,255911
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,260425
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,264822
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,267497
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,272848
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,277152
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,280572
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,283457
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,289692
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,296905
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,299604
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,302326
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,308793
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,312469
-2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,317402
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,152728
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,93723
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,104514
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,112187
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,119512
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,125708
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,129442
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,132909
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,135740
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,139331
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,143926
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,147004
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,152728
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,155580
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,158862
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,165304
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,173039
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,177266
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,185267
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,188529
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,197372
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,206768
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,215303
-2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,220350
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,72765
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,40845
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,46861
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,50675
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,53947
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,57662
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,59448
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,61534
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,63249
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,65492
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,66721
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,69850
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,72765
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,75351
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,78151
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,82309
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,86124
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,90353
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,97040
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,101198
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,110056
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,120072
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,126445
-2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,136275
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,31933
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,16807
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,19514
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,21077
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,22667
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,24426
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,25188
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,26109
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,27309
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,28184
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,28798
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,30482
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,31933
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,33384
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,34965
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,37533
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,39375
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,42547
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,45980
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,49784
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,54185
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,63692
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,67162
-2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,76771
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,1874915
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,point,NA,861216
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.010,841553
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.025,844241
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.050,846681
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.100,849959
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.150,852015
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.200,853304
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.250,855018
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.300,856129
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.350,857240
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.400,858624
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.450,859790
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.500,861216
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.550,862025
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.600,863616
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.650,864877
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.700,866509
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.750,867715
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.800,869100
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.850,871706
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.900,874722
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.950,880495
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.975,885500
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.990,892383
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,point,NA,1011257
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.010,969128
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.025,974631
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.050,979573
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.100,985706
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.150,989807
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.200,993382
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.250,997237
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.300,999410
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.350,1002109
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.400,1005158
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.450,1007997
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.500,1011257
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.550,1014166
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.600,1017565
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.650,1021841
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.700,1026187
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.750,1028501
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.800,1032146
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.850,1038770
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.900,1048128
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.950,1062813
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.975,1077008
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.990,1096565
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,point,NA,1184398
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.010,1110351
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.025,1120623
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.050,1129074
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.100,1136550
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.150,1146627
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.200,1152803
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.250,1158784
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.300,1162749
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.350,1168080
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.400,1173671
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.450,1178807
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.500,1184398
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.550,1191874
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.600,1197530
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.650,1205136
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.700,1214433
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.750,1218918
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.800,1225744
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.850,1237706
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.900,1256884
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.950,1287504
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.975,1314158
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.990,1353620
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,point,NA,1375809
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.010,1262768
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.025,1276773
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.050,1291578
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.100,1303582
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.150,1318688
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.200,1327191
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.250,1336294
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.300,1342897
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.350,1353001
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.400,1359803
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.450,1368206
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.500,1375809
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.550,1389014
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.600,1396116
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.650,1410322
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.700,1423626
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.750,1433330
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.800,1444334
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.850,1461140
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.900,1493752
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.950,1542870
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.975,1584885
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.990,1647808
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM07,North Rhine-Westphalia State,observed,NA,236655
+2022-02-07,0 wk ahead inc case,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,299364
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,428701
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,387714
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,394234
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,400325
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,407562
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,409784
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,414513
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,416269
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,418203
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,420604
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,423004
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,424831
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,428701
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,431137
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,434720
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,436905
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,439879
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,442423
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,448048
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,453673
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,461053
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,475420
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,490217
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,508167
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,517266
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,455550
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,462748
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,474607
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,483930
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,487293
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,493429
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,496674
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,499211
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,501807
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,506763
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,510304
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,517266
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,519685
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,525231
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,529125
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,533609
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,539215
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,546708
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,557151
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,569306
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,595739
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,622113
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,653207
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,566690
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,494781
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,502109
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,515785
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,527235
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,532208
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,538555
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,541106
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,545752
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,550856
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,554389
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,560147
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,566690
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,569962
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,575196
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,581674
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,587301
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,593648
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,602677
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,615044
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,630616
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,662547
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,691664
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,727454
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,562174
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,496015
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,501605
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,514359
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,524928
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,531432
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,536209
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,539054
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,542764
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,547032
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,550894
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,556941
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,562174
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,566189
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,569593
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,576402
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,582144
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,587530
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,595254
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,605467
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,620661
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,647998
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,668832
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,695864
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM07,North Rhine-Westphalia State,observed,NA,1919968
 2022-02-07,0 wk ahead cum case,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,2219332
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,2513186
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,2419324
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,2437082
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,2452303
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,2468234
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,2474897
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,2482744
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,2489915
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,2495902
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,2499385
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,2504594
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,2508484
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,2513186
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,2518022
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,2522386
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,2527561
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,2532668
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,2536592
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,2541158
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,2545014
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,2549141
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,2559322
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,2570619
-2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,2572006
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,2664799
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,2516040
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,2542216
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,2568285
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,2588466
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,2602009
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,2615070
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,2625026
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,2631236
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,2640604
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,2650614
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,2657840
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,2664799
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,2674488
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,2685247
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,2693170
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,2703233
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,2713939
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,2727589
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,2736903
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,2744826
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,2759172
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,2775873
-2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,2785187
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,2739379
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,2556587
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,2589109
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,2618345
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,2643625
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,2659651
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,2677018
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,2687009
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,2697067
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,2705717
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,2721811
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,2729790
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,2739379
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,2749571
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,2763116
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,2775387
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,2791816
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,2805026
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,2820113
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,2835066
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,2850623
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,2881133
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,2888509
-2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,2908156
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,2772912
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,2573156
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,2610082
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,2639742
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,2667155
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,2684306
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,2702282
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,2714266
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,2723553
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,2733889
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,2750442
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,2759879
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,2772912
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,2784671
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,2798602
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,2812458
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,2832007
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,2849084
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,2867809
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,2884137
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,2902262
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,2940011
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,2956639
-2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,2980457
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,36842
-2022-02-07,0 wk ahead inc case,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,56940
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,73303
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,51308
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,53921
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,56604
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,59628
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,62170
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,64559
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,66383
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,67678
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,69219
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,70514
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,71902
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,73303
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,74856
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,76256
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,77669
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,79293
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,81140
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,83035
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,85659
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,88813
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,94709
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,99569
-2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,106041
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,94520
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,54277
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,58565
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,62946
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,68655
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,73129
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,77626
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,81028
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,83661
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,86458
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,89184
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,91724
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,94520
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,97852
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,100276
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,103352
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,106567
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,109993
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,114117
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,119687
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,126141
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,138794
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,148838
-2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,162236
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,114552
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,56281
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,61873
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,68154
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,76277
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,82932
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,89244
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,94587
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,98305
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,102616
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,106803
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,110396
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,114552
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,118989
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,123144
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,127581
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,132299
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,137298
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,143828
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,152233
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,161325
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,178978
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,192070
-2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,209629
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,129089
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,56910
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,63663
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,71395
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,81815
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,89944
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,98042
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,104184
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,109043
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,114879
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,119371
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,123833
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,129089
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,134009
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,139815
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,144643
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,149869
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,155430
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,163498
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,171504
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,181038
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,196195
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,209427
-2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,224279
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,365679
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,2682843
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,2620259
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,2631328
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,2636585
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,2653004
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,2659783
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,2661766
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,2667762
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,2670944
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,2673527
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,2675925
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,2679615
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,2682843
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,2686302
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,2691421
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,2696033
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,2700368
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,2703135
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,2709454
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,2717986
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,2727440
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,2742706
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,2759862
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,2782876
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,3198988
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,3076121
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,3097088
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,3111031
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,3138603
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,3145522
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,3159045
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,3162086
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,3172569
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,3175714
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,3182004
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,3188714
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,3198988
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,3208213
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,3216285
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,3225406
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,3232325
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,3240083
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,3256437
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,3274888
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,3295541
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,3337999
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,3380457
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,3431931
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,3768683
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,3571315
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,3599438
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,3628747
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,3663816
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,3676860
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,3696682
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,3706000
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,3717012
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,3725483
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,3737850
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,3748015
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,3768683
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,3776815
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,3792232
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,3806971
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,3821372
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,3833569
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,3856440
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,3890662
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,3922512
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,3999257
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,4073461
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,4158508
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,4331446
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,4066533
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,4101125
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,4151043
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,4187824
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,4208404
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,4232925
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,4247813
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,4260730
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,4271677
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,4288316
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,4302766
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,4331446
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,4341518
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,4365820
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,4380926
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,4403039
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,4426027
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,4453613
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,4496744
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,4545129
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,4645183
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,4743485
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,4854048
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM08,Rhineland-Palatinate State,observed,NA,39695
+2022-02-07,0 wk ahead inc case,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,47849
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,55143
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,42730
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,44301
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,45622
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,47604
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,48910
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,49968
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,51127
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,52045
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,52801
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,53660
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,54431
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,55143
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,55928
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,56919
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,57976
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,58894
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,59943
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,61140
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,62645
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,64641
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,68018
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,70947
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,74852
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,61161
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,41106
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,43230
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,45463
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,48390
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,50514
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,52270
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,54435
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,55933
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,57063
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,58670
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,59854
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,61161
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,62768
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,64565
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,66254
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,68065
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,70080
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,72394
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,75090
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,78875
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,85411
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,91279
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,98877
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,66066
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,39049
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,41739
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,44488
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,48434
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,51085
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,53618
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,56720
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,58781
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,60588
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,62630
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,64083
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,66066
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,68618
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,71190
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,73527
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,76079
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,78828
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,82794
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,86701
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,92121
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,101977
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,111146
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,122730
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,69581
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,36779
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,39729
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,42867
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,47587
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,50678
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,53817
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,57852
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,60236
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,62454
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,65050
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,66914
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,69581
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,72766
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,76117
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,78926
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,82182
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,85745
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,90489
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,95751
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,102453
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,114748
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,126358
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,140328
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM08,Rhineland-Palatinate State,observed,NA,374770
 2022-02-07,0 wk ahead cum case,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,422619
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,498307
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,472071
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,475576
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,478900
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,482612
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,485715
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,488292
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,490605
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,492060
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,493639
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,495260
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,496756
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,498307
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,500094
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,501950
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,503419
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,505358
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,507505
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,509763
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,512284
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,516121
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,522341
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,528242
-2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,535016
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,592923
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,526806
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,534370
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,542228
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,551194
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,559090
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,566174
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,571745
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,575545
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,580010
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,584437
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,588533
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,592923
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,597351
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,601963
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,606759
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,611408
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,617570
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,623584
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,631885
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,642068
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,660738
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,676566
-2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,696932
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,707738
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,583062
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,596802
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,610609
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,627546
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,641829
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,655637
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,666316
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,674070
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,682640
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,690734
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,698896
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,707738
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,717737
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,725423
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,733925
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,743584
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,754670
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,767594
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,783986
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,803303
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,840168
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,868804
-2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,906213
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,836766
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,640127
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,660687
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,681930
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,709311
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,732210
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,752868
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,770603
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,782978
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,797009
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,810457
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,822345
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,836766
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,851187
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,864537
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,878959
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,893380
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,909750
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,930701
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,956133
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,985171
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,1038082
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,1078034
-2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,1128314
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM09,Saarland State,observed,NA,10474
-2022-02-07,0 wk ahead inc case,2022-02-05,GM09,Saarland State,observed,NA,15892
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,point,NA,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.010,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.025,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.050,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.100,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.150,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.200,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.250,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.300,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.350,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.400,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.450,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.500,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.550,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.600,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.650,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.700,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.750,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.800,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.850,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.900,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.950,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.975,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.990,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,point,NA,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.010,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.025,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.050,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.100,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.150,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.200,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.250,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.300,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.350,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.400,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.450,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.500,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.550,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.600,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.650,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.700,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.750,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.800,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.850,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.900,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.950,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.975,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.990,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,point,NA,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.010,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.025,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.050,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.100,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.150,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.200,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.250,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.300,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.350,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.400,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.450,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.500,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.550,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.600,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.650,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.700,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.750,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.800,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.850,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.900,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.950,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.975,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.990,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,point,NA,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.010,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.025,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.050,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.100,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.150,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.200,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.250,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.300,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.350,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.400,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.450,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.500,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.550,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.600,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.650,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.700,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.750,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.800,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.850,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.900,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.950,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.975,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.990,0
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM09,Saarland State,observed,NA,98577
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,480162
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,464432
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,466725
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,468572
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,470945
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,472845
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,473996
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,475121
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,476299
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,477458
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,478270
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,479234
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,480162
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,481126
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,482303
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,483187
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,484463
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,485596
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,486890
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,488558
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,491110
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,494768
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,498284
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,502736
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,541191
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,505823
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,510289
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,514059
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,519512
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,523260
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,526514
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,529656
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,532304
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,534616
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,537129
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,539239
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,541191
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,543929
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,546510
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,549562
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,552367
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,555442
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,558942
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,563745
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,569804
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,580083
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,589261
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,601313
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,607752
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,545285
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,552300
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,558980
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,568054
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,574439
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,580068
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,586537
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,590990
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,594939
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,599980
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,603467
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,607752
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,612121
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,617750
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,623631
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,628672
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,634721
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,641989
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,650139
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,661733
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,681687
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,700507
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,723444
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,676936
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,581958
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,592273
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,601680
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,615628
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,625295
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,633858
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,644433
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,651505
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,657538
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,664804
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,670383
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,676936
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,685305
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,693803
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,701913
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,710931
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,720078
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,732534
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,745834
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,764453
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,796242
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,826409
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,864232
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM09,Saarland State,observed,NA,10936
+2022-02-07,0 wk ahead inc case,2022-02-05,GM09,Saarland State,observed,NA,14034
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,point,NA,16879
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.010,14154
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.025,14513
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.050,14821
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.100,15247
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.150,15564
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.200,15817
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.250,16020
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.300,16225
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.350,16420
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.400,16563
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.450,16731
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.500,16879
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.550,17100
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.600,17333
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.650,17477
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.700,17639
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.750,17791
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.800,18051
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.850,18250
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.900,18579
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.950,19208
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.975,19794
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.990,20410
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,point,NA,17865
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.010,13937
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.025,14453
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.050,14838
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.100,15435
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.150,15911
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.200,16266
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.250,16607
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.300,16926
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.350,17208
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.400,17486
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.450,17674
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.500,17865
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.550,18265
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.600,18531
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.650,18767
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.700,19047
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.750,19261
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.800,19533
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.850,19904
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.900,20366
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.950,21264
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.975,22050
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.990,22998
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,point,NA,17238
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.010,12927
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.025,13513
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.050,13958
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.100,14563
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.150,15137
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.200,15498
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.250,15846
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.300,16171
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.350,16510
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.400,16779
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.450,16979
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.500,17238
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.550,17613
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.600,17835
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.650,18104
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.700,18391
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.750,18669
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.800,18876
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.850,19269
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.900,19748
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.950,20508
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.975,21257
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.990,22200
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,point,NA,15192
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.010,11346
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.025,11900
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.050,12295
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.100,12884
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.150,13376
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.200,13656
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.250,14003
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.300,14232
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.350,14550
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.400,14720
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.450,14954
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.500,15192
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.550,15388
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.600,15575
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.650,15818
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.700,15970
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.750,16178
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.800,16405
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.850,16654
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.900,17043
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.950,17585
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.975,18131
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.990,18836
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM09,Saarland State,observed,NA,100435
 2022-02-07,0 wk ahead cum case,2022-02-05,GM09,Saarland State,observed,NA,114469
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,point,NA,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.010,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.025,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.050,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.100,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.150,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.200,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.250,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.300,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.350,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.400,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.450,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.500,54968
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.550,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.600,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.650,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.700,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.750,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.800,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.850,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.900,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.950,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.975,54969
-2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.990,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,point,NA,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.010,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.025,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.050,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.100,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.150,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.200,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.250,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.300,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.350,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.400,54968
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.450,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.500,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.550,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.600,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.650,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.700,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.750,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.800,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.850,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.900,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.950,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.975,54969
-2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.990,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,point,NA,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.010,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.025,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.050,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.100,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.150,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.200,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.250,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.300,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.350,54968
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.400,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.450,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.500,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.550,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.600,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.650,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.700,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.750,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.800,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.850,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.900,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.950,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.975,54969
-2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.990,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,point,NA,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.010,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.025,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.050,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.100,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.150,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.200,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.250,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.300,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.350,54968
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.400,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.450,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.500,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.550,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.600,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.650,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.700,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.750,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.800,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.850,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.900,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.950,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.975,54969
-2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.990,54969
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,29983
-2022-02-07,0 wk ahead inc case,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,31500
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,point,NA,31643
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,20196
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,21977
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,23506
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,25389
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,26528
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,27512
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,28207
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,28963
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,29658
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,30240
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,30959
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,31643
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,32453
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,33274
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,34018
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,34779
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,35661
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,36470
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,37633
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,39270
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,41813
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,44253
-2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,47276
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,point,NA,32405
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,15842
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,18145
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,20172
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,22834
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,24482
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,25915
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,26969
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,28044
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,29129
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,30091
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,31187
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,32405
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,33541
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,34923
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,36151
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,37421
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,38966
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,40266
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,42355
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,45293
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,49961
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,54291
-2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,60156
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,point,NA,32440
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,12407
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,14901
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,17173
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,20331
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,22340
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,24113
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,25416
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,26801
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,28256
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,29447
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,30902
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,32440
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,34061
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,35876
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,37663
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,39339
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,41417
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,43371
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,46252
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,50381
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,57183
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,63473
-2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,72132
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,point,NA,31995
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,9660
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,12200
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,14577
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,17973
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,20205
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,22210
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,23698
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,25299
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,26981
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,28437
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,30038
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,31995
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,33936
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,36103
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,38238
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,40308
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,43025
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,45354
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,48863
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,54022
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,62529
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,70324
-2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,80772
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,210917
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,point,NA,133126
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.010,129637
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.025,130104
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.050,130599
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.100,131100
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.150,131491
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.200,131760
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.250,132078
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.300,132277
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.350,132437
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.400,132638
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.450,132864
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.500,133126
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.550,133290
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.600,133477
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.650,133723
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.700,133910
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.750,134116
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.800,134358
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.850,134678
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.900,135054
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.950,135716
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.975,136479
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.990,137168
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,point,NA,151016
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.010,143602
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.025,144626
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.050,145431
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.100,146644
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.150,147415
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.200,148129
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.250,148704
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.300,149229
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.350,149720
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.400,150147
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.450,150517
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.500,151016
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.550,151481
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.600,152006
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.650,152490
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.700,152894
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.750,153348
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.800,153952
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.850,154527
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.900,155396
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.950,156991
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.975,158528
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.990,160119
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,point,NA,168169
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.010,156619
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.025,158106
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.050,159329
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.100,161157
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.150,162547
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.200,163602
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.250,164484
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.300,165389
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.350,166214
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.400,166969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.450,167465
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.500,168169
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.550,169109
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.600,169864
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.650,170516
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.700,171340
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.750,172015
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.800,172817
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.850,173768
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.900,175169
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.950,177372
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.975,179661
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.990,182216
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,point,NA,183298
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.010,167915
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.025,170023
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.050,171610
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.100,174059
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.150,175936
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.200,177277
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.250,178545
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.300,179668
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.350,180863
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.400,181820
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.450,182494
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.500,183298
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.550,184639
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.600,185501
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.650,186356
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.700,187378
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.750,188211
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.800,189131
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.850,190414
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.900,192189
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.950,194718
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.975,197363
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.990,200863
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM10,Schleswig-Holstein State,observed,NA,29363
+2022-02-07,0 wk ahead inc case,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,27506
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,point,NA,23428
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,16049
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,17264
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,18249
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,19350
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,20134
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,20774
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,21308
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,21784
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,22220
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,22655
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,23051
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,23428
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,23878
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,24240
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,24731
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,25221
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,25664
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,26279
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,26982
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,27889
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,29397
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,30744
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,32523
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,point,NA,20459
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,11203
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,12571
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,13727
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,15149
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,16087
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,16905
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,17553
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,18197
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,18763
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,19385
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,19886
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,20459
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,21091
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,21565
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,22290
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,22999
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,23615
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,24482
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,25539
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,27077
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,29322
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,31470
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,34294
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,point,NA,17731
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,7839
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,9136
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,10323
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,11779
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,12792
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,13694
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,14402
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,15137
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,15747
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,16490
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,17038
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,17731
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,18446
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,19042
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,19861
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,20742
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,21526
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,22552
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,23850
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,25820
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,28768
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,31543
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,35399
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,point,NA,15217
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,5489
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,6634
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,7740
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,9108
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,10134
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,11009
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,11741
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,12536
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,13157
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,13944
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,14509
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,15217
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,16012
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,16712
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,17579
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,18510
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,19441
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,20578
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,22042
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,24325
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,27745
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,31038
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,35604
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM10,Schleswig-Holstein State,observed,NA,214911
 2022-02-07,0 wk ahead cum case,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,242417
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,point,NA,275530
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,261178
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,263521
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,265440
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,267747
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,269177
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,270334
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,271254
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,272181
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,273158
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,273826
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,274581
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,275530
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,276291
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,277463
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,278332
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,279144
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,280186
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,281214
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,282651
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,284484
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,287473
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,290190
-2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,293798
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,point,NA,307708
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,277246
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,281837
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,285627
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,290808
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,293764
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,296198
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,298232
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,300336
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,302318
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,303970
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,305865
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,307708
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,309864
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,312298
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,314576
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,316697
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,319061
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,321443
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,324730
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,329633
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,337213
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,344498
-2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,353817
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,point,NA,340120
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,289835
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,296882
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,303001
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,311037
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,316136
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,320402
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,323708
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,327170
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,330353
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,333320
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,336813
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,340120
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,344138
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,348217
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,352019
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,355944
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,360425
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,364721
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,370964
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,379927
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,394360
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,407928
-2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,425668
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,point,NA,372318
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,299540
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,309004
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,317630
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,329192
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,336325
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,342666
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,347422
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,352550
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,357399
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,361828
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,367050
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,372318
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,378006
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,384393
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,390175
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,396236
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,403369
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,409989
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,420060
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,434000
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,456612
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,478338
-2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,506359
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM11,Brandenburg State,observed,NA,34880
-2022-02-07,0 wk ahead inc case,2022-02-05,GM11,Brandenburg State,observed,NA,51629
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,point,NA,64381
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.010,43847
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.025,46494
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.050,49039
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.100,52034
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.150,54221
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.200,56071
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.250,57522
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.300,59055
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.350,60640
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.400,61805
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.450,63052
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.500,64381
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.550,65750
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.600,67304
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.650,68643
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.700,70104
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.750,71535
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.800,73436
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.850,75797
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.900,79017
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.950,83851
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.975,88236
-2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.990,94062
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,point,NA,77322
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.010,43898
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.025,47823
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.050,51747
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.100,56503
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.150,60144
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.200,63304
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.250,65665
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.300,68276
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.350,70903
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.400,73098
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.450,75060
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.500,77322
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.550,79633
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.600,82244
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.650,84622
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.700,87166
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.750,89444
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.800,92770
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.850,96644
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.900,101749
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.950,109781
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.975,117131
-2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.990,125312
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,point,NA,84344
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.010,42559
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.025,47388
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.050,52130
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.100,58218
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.150,62857
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.200,66858
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.250,69789
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.300,73170
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.350,76187
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.400,79188
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.450,81533
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.500,84344
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.550,87035
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.600,89863
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.650,92381
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.700,95537
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.750,98589
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.800,101814
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.850,105608
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.900,110609
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.950,118697
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.975,125629
-2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.990,133855
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,point,NA,82463
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.010,39950
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.025,45047
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.050,50182
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.100,56797
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.150,61774
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.200,65907
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.250,68798
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.300,72231
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.350,75149
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.400,77987
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.450,80113
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.500,82463
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.550,85130
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.600,87216
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.650,89196
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.700,91150
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.750,93236
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.800,95626
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.850,98583
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.900,102716
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.950,109172
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.975,115205
-2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.990,122150
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM11,Brandenburg State,observed,NA,327071
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,point,NA,267061
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,257547
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,259183
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,260494
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,261823
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,262886
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,263743
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,264362
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,264999
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,265586
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,266099
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,266557
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,267061
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,267524
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,268125
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,268592
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,269165
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,269765
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,270508
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,271369
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,272547
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,274229
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,275930
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,278074
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,point,NA,287514
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,268814
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,271915
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,274379
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,277052
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,278997
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,280622
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,281989
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,283186
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,284402
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,285490
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,286427
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,287514
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,288651
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,289658
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,290786
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,292172
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,293359
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,295004
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,296939
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,299463
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,303432
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,307232
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,312229
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,point,NA,305294
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,276804
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,281064
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,284617
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,288877
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,291824
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,294400
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,296437
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,298357
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,300209
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,301977
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,303543
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,305294
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,307146
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,308662
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,310733
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,312888
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,314892
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,317535
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,320752
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,325281
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,332235
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,338701
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,347272
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,point,NA,320606
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,282262
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,287690
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,292300
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,298051
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,301917
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,305412
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,308114
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,310816
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,313418
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,316046
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,317905
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,320606
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,323184
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,325241
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,328414
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,331488
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,334288
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,338056
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,342840
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,349557
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,359893
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,369758
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,382820
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM11,Brandenburg State,observed,NA,35399
+2022-02-07,0 wk ahead inc case,2022-02-05,GM11,Brandenburg State,observed,NA,45665
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,point,NA,52787
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.010,40743
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.025,42238
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.050,43524
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.100,45326
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.150,46644
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.200,47702
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.250,48694
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.300,49412
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.350,50326
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.400,51148
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.450,52043
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.500,52787
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.550,53714
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.600,54601
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.650,55456
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.700,56370
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.750,57487
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.800,58668
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.850,60111
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.900,61893
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.950,64908
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.975,67800
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.990,71664
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,point,NA,58805
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.010,40367
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.025,42345
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.050,44128
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.100,46885
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.150,49017
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.200,50626
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.250,52195
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.300,53414
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.350,54767
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.400,56171
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.450,57617
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.500,58805
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.550,60281
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.600,61808
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.650,63141
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.700,64494
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.750,66431
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.800,68389
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.850,70889
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.900,73790
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.950,78648
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.975,83496
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.990,89318
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,point,NA,61172
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.010,38479
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.025,40853
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.050,43013
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.100,46303
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.150,48813
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.200,50984
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.250,52861
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.300,54501
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.350,56027
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.400,57904
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.450,59623
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.500,61172
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.550,62709
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.600,64666
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.650,66147
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.700,67764
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.750,70138
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.800,72626
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.850,75543
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.900,78788
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.950,83921
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.975,89292
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.990,94866
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,point,NA,59067
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.010,35534
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.025,37995
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.050,40341
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.100,43738
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.150,46267
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.200,48661
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.250,50649
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.300,52213
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.350,53835
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.400,55823
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.450,57484
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.500,59067
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.550,60543
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.600,62406
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.650,63787
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.700,65466
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.750,67484
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.800,69819
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.850,71953
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.900,74935
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.950,78806
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.975,82571
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.990,87300
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM11,Brandenburg State,observed,NA,333035
 2022-02-07,0 wk ahead cum case,2022-02-05,GM11,Brandenburg State,observed,NA,378700
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,point,NA,445477
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.010,419965
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.025,423711
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.050,427209
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.100,430941
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.150,433587
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.200,435638
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.250,437443
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.300,439272
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.350,440953
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.400,442338
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.450,443957
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.500,445477
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.550,447158
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.600,448728
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.650,450446
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.700,452152
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.750,453709
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.800,455749
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.850,458555
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.900,462164
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.950,467738
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.975,472720
-2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.990,479444
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,point,NA,522801
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.010,464171
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.025,471961
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.050,479203
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.100,487657
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.150,493947
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.200,498997
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.250,503209
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.300,507624
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.350,512038
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.400,515674
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.450,518992
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.500,522801
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.550,526638
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.600,531139
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.650,535035
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.700,539161
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.750,543085
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.800,548394
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.850,555232
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.900,564090
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.950,577160
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.975,589423
-2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.990,604485
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,point,NA,606900
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.010,506958
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.025,519543
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.050,531529
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.100,546096
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.150,556837
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.200,566057
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.250,572879
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.300,580624
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.350,588368
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.400,594315
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.450,600584
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.500,606900
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.550,613538
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.600,621283
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.650,627782
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.700,634559
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.750,641796
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.800,650094
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.850,661112
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.900,674803
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.950,695870
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.975,714171
-2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.990,735100
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,point,NA,690149
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.010,547396
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.025,564659
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.050,581980
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.100,602895
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.150,618625
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.200,631999
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.250,641779
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.300,653032
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.350,663755
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.400,673063
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.450,680604
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.500,690149
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.550,699399
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.600,708589
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.650,717132
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.700,726323
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.750,736692
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.800,747179
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.850,759492
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.900,776519
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.950,802560
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.975,824241
-2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.990,851047
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,16387
-2022-02-07,0 wk ahead inc case,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,23142
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,31462
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,21165
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,22892
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,24277
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,26015
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,27089
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,28012
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,28708
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,29289
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,29802
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,30378
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,30959
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,31462
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,32002
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,32495
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,33070
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,33631
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,34305
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,35234
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,36219
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,37319
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,39519
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,41308
-2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,43746
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,40132
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,21532
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,24462
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,26769
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,29809
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,31935
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,33510
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,34805
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,35838
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,37012
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,37965
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,39118
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,40132
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,40964
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,42018
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,43211
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,44516
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,45719
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,47375
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,49341
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,51709
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,56233
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,59694
-2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,64640
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,47800
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,21459
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,25336
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,28642
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,32652
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,35931
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,38214
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,39927
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,41706
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,43207
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,44893
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,46313
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,47800
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,49048
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,50588
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,52221
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,54186
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,55926
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,58156
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,60958
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,64609
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,70557
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,75721
-2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,82439
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,52238
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,20960
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,25590
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,29798
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,34427
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,38554
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,41256
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,43197
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,45315
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,47297
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,49089
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,50799
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,52238
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,54220
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,55863
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,57628
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,59718
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,61863
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,63818
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,67212
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,71352
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,77868
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,84208
-2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,91919
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,140597
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,point,NA,433848
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.010,418264
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.025,420680
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.050,422347
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.100,424885
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.150,426455
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.200,427723
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.250,428968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.300,430049
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.350,431034
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.400,431847
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.450,432912
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.500,433848
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.550,435076
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.600,435995
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.650,437011
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.700,438248
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.750,439394
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.800,440826
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.850,442331
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.900,444478
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.950,447763
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.975,451399
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.990,455905
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,point,NA,492701
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.010,458793
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.025,463298
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.050,466727
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.100,471962
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.150,475446
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.200,478601
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.250,481319
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.300,483362
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.350,485842
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.400,488031
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.450,490475
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.500,492701
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.550,495309
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.600,497753
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.650,500124
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.700,502897
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.750,505925
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.800,509098
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.850,513056
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.900,518054
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.950,526207
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.975,534671
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.990,545067
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,point,NA,553679
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.010,497485
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.025,504032
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.050,510080
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.100,518183
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.150,524584
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.200,529516
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.250,534155
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.300,537766
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.350,541994
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.400,545928
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.450,550332
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.500,553679
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.550,557906
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.600,562457
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.650,566362
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.700,570648
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.750,575962
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.800,581482
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.850,588675
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.900,596396
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.950,610077
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.975,624229
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.990,639466
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,point,NA,612666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.010,533413
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.025,542335
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.050,550445
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.100,561993
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.150,570992
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.200,578253
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.250,584549
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.300,589917
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.350,596020
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.400,601967
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.450,607336
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.500,612666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.550,618382
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.600,624870
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.650,630625
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.700,635878
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.750,643679
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.800,651597
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.850,660750
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.900,671294
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.950,688983
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.975,706672
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.990,725481
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM12,Mecklenburg-Western Pomerania State,observed,NA,16900
+2022-02-07,0 wk ahead inc case,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,20216
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,23405
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18406
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,19069
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,19595
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,20396
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,20887
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,21309
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,21677
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,21990
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,22349
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,22722
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,23055
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,23405
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,23779
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,24112
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,24439
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,24858
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,25212
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,25622
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,26208
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,27047
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,28316
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,29514
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,31010
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,25586
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,17581
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,18543
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,19354
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,20549
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,21287
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,22036
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,22654
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,23252
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,23798
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,24385
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,25004
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,25586
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,26267
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,26922
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,27489
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,28149
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,28814
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,29583
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,30592
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,32198
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,34537
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,36814
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,39771
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,27317
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,16643
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,17723
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,18796
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,20397
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,21321
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,22356
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,23235
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,24024
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,24821
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,25581
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,26445
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,27317
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,28255
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,29201
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,30035
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,30907
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,31920
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,33059
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,34579
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,36873
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,40351
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,43680
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,48224
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,28428
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,15533
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,16812
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,18055
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,19849
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,21030
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,22327
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,23357
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,24316
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,25285
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,26279
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,27372
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,28428
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,29530
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,30800
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,31750
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,32922
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,34139
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,35596
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,37558
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,40445
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,44859
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,48873
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,54610
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM12,Mecklenburg-Western Pomerania State,observed,NA,143523
 2022-02-07,0 wk ahead cum case,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,163739
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,197419
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,185314
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,187283
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,189063
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,191127
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,192387
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,193333
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,194214
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,194835
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,195538
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,196177
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,196845
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,197419
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,197992
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,198542
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,199228
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,199849
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,200606
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,201706
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,202788
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,203994
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,206555
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,208441
-2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,211286
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,237609
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,207038
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,211911
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,215895
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,220911
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,224260
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,226879
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,229069
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,230815
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,232545
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,234228
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,235910
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,237609
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,238926
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,240577
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,242355
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,244196
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,246243
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,248989
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,252053
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,255751
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,262751
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,268195
-2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,275798
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,285461
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,228653
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,237292
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,244516
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,253849
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,260351
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,265292
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,269048
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,272342
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,275781
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,278959
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,282224
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,285461
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,287801
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,291124
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,294592
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,298435
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,302249
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,307132
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,313056
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,320106
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,333080
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,343829
-2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,358132
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,337792
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,249617
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,262973
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,274278
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,288304
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,299064
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,306265
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,312294
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,318198
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,322761
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,328246
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,333312
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,337792
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,341937
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,347045
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,352362
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,358684
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,364253
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,370952
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,379618
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,392137
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,409805
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,425841
-2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,446482
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM13,Free State of Saxony,observed,NA,24031
-2022-02-07,0 wk ahead inc case,2022-02-05,GM13,Free State of Saxony,observed,NA,45104
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,point,NA,71630
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.010,49715
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.025,52617
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.050,55013
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.100,58144
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.150,60564
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.200,62394
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.250,64044
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.300,65814
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.350,67259
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.400,68631
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.450,70124
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.500,71630
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.550,73243
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.600,75025
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.650,76554
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.700,78108
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.750,80191
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.800,82310
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.850,84658
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.900,87969
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.950,93316
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.975,98289
-2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.990,104839
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,point,NA,107621
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.010,60884
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.025,66132
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.050,71049
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.100,77734
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.150,82678
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.200,86794
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.250,90744
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.300,94501
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.350,97650
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.400,100992
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.450,104141
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.500,107621
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.550,112151
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.600,115908
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.650,119306
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.700,122924
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.750,127620
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.800,133227
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.850,138724
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.900,146762
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.950,159662
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.975,172037
-2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.990,187644
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,point,NA,148206
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.010,72228
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.025,80357
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.050,87955
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.100,98782
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.150,107026
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.200,113826
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.250,120512
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.300,126134
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.350,131833
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.400,137379
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.450,142622
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.500,148206
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.550,155310
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.600,161768
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.650,166973
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.700,173089
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.750,180269
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.800,188665
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.850,197136
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.900,210318
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.950,228591
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.975,245686
-2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.990,264339
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,point,NA,181394
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.010,82403
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.025,93398
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.050,103679
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.100,118112
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.150,129005
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.200,137958
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.250,147013
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.300,154366
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.350,161310
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.400,168629
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.450,174484
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.500,181394
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.550,189122
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.600,197121
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.650,202772
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.700,210738
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.750,217035
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.800,224014
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.850,233205
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.900,243451
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.950,261833
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.975,276233
-2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.990,294513
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM13,Free State of Saxony,observed,NA,714930
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,189205
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,182884
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,183727
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,184525
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,185567
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,186176
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,186718
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,187127
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,187491
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,187970
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,188365
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,188775
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,189205
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,189597
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,189982
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,190310
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,190839
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,191230
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,191748
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,192458
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,193389
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,194844
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,196096
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,197908
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,214808
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,200664
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,202383
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,203833
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,206229
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,207627
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,208747
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,209780
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,210710
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,211708
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,212793
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,213722
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,214808
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,215806
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,216848
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,217760
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,219019
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,220087
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,221207
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,223073
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,225505
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,229403
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,233093
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,237599
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,242079
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,217345
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,220154
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,222530
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,226606
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,229078
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,231084
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,233043
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,234760
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,236574
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,238403
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,240201
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,242079
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,244134
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,246011
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,247777
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,249992
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,252030
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,254085
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,257552
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,262431
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,269750
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,276748
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,285784
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,270392
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,232903
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,237132
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,240615
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,246486
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,250018
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,253426
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,256312
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,259223
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,261959
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,264720
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,267482
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,270392
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,273577
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,276636
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,279771
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,282781
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,286164
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,289722
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,294896
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,302857
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,314524
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,325445
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,340172
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM13,Free State of Saxony,observed,NA,26168
+2022-02-07,0 wk ahead inc case,2022-02-05,GM13,Free State of Saxony,observed,NA,40065
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,point,NA,53581
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.010,38274
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.025,40523
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.050,42604
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.100,45051
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.150,46788
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.200,47966
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.250,49159
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.300,50100
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.350,51064
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.400,51890
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.450,52762
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.500,53581
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.550,54361
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.600,55004
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.650,55868
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.700,56939
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.750,58002
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.800,59050
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.850,60465
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.900,62523
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.950,65897
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.975,68612
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.990,72384
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,point,NA,68601
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.010,39188
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.025,42929
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.050,46946
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.100,51530
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.150,54704
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.200,57134
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.250,59304
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.300,61264
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.350,63143
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.400,64730
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.450,66674
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.500,68601
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.550,69735
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.600,71306
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.650,72974
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.700,75290
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.750,77768
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.800,79906
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.850,82595
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.900,87324
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.950,94953
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.975,101205
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.990,108834
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,point,NA,83824
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.010,39458
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.025,44755
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.050,50384
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.100,57235
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.150,62328
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.200,65690
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.250,69409
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.300,72414
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.350,75164
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.400,78221
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.450,81048
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.500,83824
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.550,85861
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.600,88535
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.650,91133
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.700,94698
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.750,98621
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.800,102492
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.850,106847
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.900,114283
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.950,126432
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.975,136975
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.990,149073
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,point,NA,97330
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.010,39011
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.025,45666
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.050,53112
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.100,61773
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.150,68581
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.200,73261
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.250,78214
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.300,82013
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.350,85934
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.400,90006
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.450,93805
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.500,97330
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.550,100491
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.600,104046
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.650,107602
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.700,111857
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.750,117023
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.800,122432
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.850,128176
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.900,137901
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.950,152823
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.975,165830
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.990,181420
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM13,Free State of Saxony,observed,NA,719969
 2022-02-07,0 wk ahead cum case,2022-02-05,GM13,Free State of Saxony,observed,NA,760034
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,point,NA,835137
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.010,809656
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.025,813312
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.050,816310
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.100,819898
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.150,822718
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.200,824868
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.250,826730
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.300,828647
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.350,830112
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.400,831769
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.450,833631
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.500,835137
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.550,836794
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.600,838642
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.650,840381
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.700,842188
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.750,844393
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.800,846871
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.850,849527
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.900,852936
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.950,858920
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.975,864438
-2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.990,871736
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,point,NA,942827
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.010,871026
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.025,879713
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.050,887617
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.100,897622
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.150,905403
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.200,911702
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.250,917384
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.300,922900
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.350,927758
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.400,933028
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.450,937639
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.500,942827
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.550,948673
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.600,954437
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.650,959912
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.700,965059
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.750,972346
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.800,980127
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.850,987908
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.900,1000053
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.950,1018045
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.975,1035789
-2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.990,1058556
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,point,NA,1090523
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.010,943632
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.025,960252
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.050,975843
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.100,996421
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.150,1012487
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.200,1025783
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.250,1037734
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.300,1049368
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.350,1059340
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.400,1069946
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.450,1080630
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.500,1090523
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.550,1104690
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.600,1116007
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.650,1126692
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.700,1137534
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.750,1152493
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.800,1169113
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.850,1185258
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.900,1209872
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.950,1247070
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.975,1281339
-2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.990,1323443
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,point,NA,1271698
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.010,1026220
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.025,1053957
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.050,1079448
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.100,1115046
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.150,1141997
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.200,1163782
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.250,1184781
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.300,1203984
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.350,1220716
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.400,1238796
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.450,1255191
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.500,1271698
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.550,1294158
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.600,1313136
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.650,1329531
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.700,1348734
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.750,1370294
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.800,1393427
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.850,1418918
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.900,1455639
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.950,1507520
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.975,1552438
-2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.990,1605891
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,14418
-2022-02-07,0 wk ahead inc case,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,28833
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,50537
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,43192
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,44260
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,45105
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,45920
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,46575
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,47229
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,47574
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,48229
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,48982
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,49420
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,50136
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,50537
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,50994
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,51506
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,52148
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,52790
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,53765
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,54796
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,56018
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,57827
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,60561
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,63228
-2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,66919
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,79531
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,64557
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,66133
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,67667
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,69357
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,70805
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,71922
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,72897
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,74573
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,76121
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,77095
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,78227
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,79531
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,80620
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,81823
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,83328
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,85320
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,87540
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,89933
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,92770
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,96840
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,104090
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,110724
-2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,119966
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,111232
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,88223
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,90719
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,92673
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,95712
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,97756
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,99438
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,100939
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,103526
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,105914
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,107361
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,109369
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,111232
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,113240
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,115085
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,117618
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,121181
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,123804
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,127494
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,132197
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,138257
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,147971
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,157576
-2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,167959
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,133509
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,107961
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,110801
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,112984
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,116626
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,118690
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,120755
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,122477
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,125318
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,127711
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,129183
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,131498
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,133509
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,135600
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,137664
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,140097
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,143148
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,146211
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,149512
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,153404
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,158137
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,164896
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,170116
-2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,176941
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,259743
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,point,NA,816842
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.010,799254
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.025,801948
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.050,804502
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.100,807196
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.150,809154
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.200,810716
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.250,811813
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.300,812927
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.350,814007
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.400,814972
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.450,815867
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.500,816842
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.550,817702
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.600,818474
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.650,819615
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.700,820589
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.750,821774
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.800,823108
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.850,824670
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.900,826873
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.950,830682
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.975,833595
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.990,838133
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,point,NA,885310
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.010,838691
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.025,845187
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.050,851435
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.100,858553
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.150,864104
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.200,867813
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.250,871247
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.300,874458
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.350,877146
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.400,879685
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.450,882647
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.500,885310
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.550,887600
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.600,889591
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.650,892628
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.700,895963
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.750,899423
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.800,903082
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.850,907015
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.900,914208
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.950,925533
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.975,934742
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.990,946789
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,point,NA,969297
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.010,878462
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.025,889842
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.050,902077
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.100,916377
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.150,926297
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.200,933547
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.250,940647
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.300,947042
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.350,952329
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.400,957364
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.450,963607
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.500,969297
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.550,973225
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.600,978109
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.650,983748
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.700,990596
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.750,998149
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.800,1005249
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.850,1013859
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.900,1028360
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.950,1051623
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.975,1071160
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.990,1095077
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,point,NA,1066955
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.010,917582
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.025,935587
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.050,955208
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.100,978381
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.150,995660
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.200,1006721
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.250,1018833
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.300,1028925
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.350,1038049
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.400,1047496
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.450,1057266
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.500,1066955
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.550,1073172
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.600,1082458
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.650,1090855
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.700,1102563
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.750,1115158
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.800,1127431
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.850,1142207
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.900,1166026
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.950,1204621
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.975,1236918
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.990,1275190
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM14,Sachsen-Anhalt State,observed,NA,16089
+2022-02-07,0 wk ahead inc case,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,25265
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,51172
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,44587
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,45383
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,46589
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,47638
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,48283
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,49164
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,49484
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,49877
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,50090
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,50415
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,50796
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,51172
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,51402
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,51773
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,52244
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,52743
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,53242
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,53988
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,54869
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,56137
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,58279
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,60299
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,63586
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,83002
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,69363
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,70948
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,73372
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,75377
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,77219
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,78465
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,79088
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,79914
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,80767
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,81512
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,82297
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,83002
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,83598
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,84478
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,85521
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,86631
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,87783
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,89584
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,91710
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,95326
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,100324
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,105674
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,114003
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,120345
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,98672
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,101757
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,105657
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,108590
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,111695
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,113323
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,114364
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,115424
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,116786
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,118055
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,119342
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,120345
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,121689
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,122938
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,124566
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,126251
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,128390
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,131058
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,134503
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,140560
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,148454
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,157350
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,168839
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,149600
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,125049
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,128944
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,133370
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,136749
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,139936
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,141721
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,143064
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,144097
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,145543
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,147136
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,148700
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,149600
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,151164
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,152610
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,154366
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,156195
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,158541
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,161108
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,164369
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,170286
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,177323
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,184450
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,191930
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM14,Sachsen-Anhalt State,observed,NA,263311
 2022-02-07,0 wk ahead cum case,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,288576
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,342027
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,332251
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,333938
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,334974
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,336146
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,337096
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,337925
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,338583
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,339176
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,339912
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,340677
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,341441
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,342027
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,342571
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,343164
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,343793
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,344350
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,345393
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,346680
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,348102
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,349946
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,352997
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,355749
-2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,359758
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,421451
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,396961
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,400185
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,402940
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,405651
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,408213
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,410220
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,411501
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,414021
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,416220
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,417629
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,419828
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,421451
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,423202
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,424825
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,427131
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,429565
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,432917
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,436461
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,440795
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,446966
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,456894
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,466481
-2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,479356
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,532874
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,485624
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,491146
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,496036
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,501400
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,505857
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,509486
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,512523
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,517650
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,522383
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,525222
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,529009
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,532874
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,536305
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,539855
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,544666
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,550267
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,557051
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,564071
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,572630
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,584343
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,605168
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,623508
-2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,647487
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,666370
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,593516
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,601824
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,608938
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,617714
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,625192
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,630125
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,634746
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,642899
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,650376
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,654115
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,660139
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,666370
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,672134
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,677534
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,684337
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,694203
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,703030
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,713883
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,726086
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,742962
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,770224
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,794734
-2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,821788
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM15,Free State of Thuringia,observed,NA,8614
-2022-02-07,0 wk ahead inc case,2022-02-05,GM15,Free State of Thuringia,observed,NA,16529
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,point,NA,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,0
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,1
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,1
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,1
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,1
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,2
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,2
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,2
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,3
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,4
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,4
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,4
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,5
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,6
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,6
-2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,6
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,point,NA,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,0
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,1
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,2
-2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,2
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,point,NA,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,0
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,1
-2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,1
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,point,NA,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,0
-2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,0
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM15,Free State of Thuringia,observed,NA,316681
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,343173
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,333972
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,335375
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,336890
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,338253
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,339250
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,340454
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,341098
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,341484
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,341790
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,342129
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,342701
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,343173
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,343512
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,344043
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,344675
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,345094
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,345752
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,346709
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,347653
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,349136
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,351669
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,353836
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,357386
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,426304
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,403488
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,406307
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,410355
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,414181
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,416457
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,419195
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,420263
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,421471
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,422297
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,423726
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,424935
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,426304
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,427271
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,428257
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,430130
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,431963
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,433735
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,436111
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,439252
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,444065
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,451657
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,459349
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,471069
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,546683
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,502775
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,507579
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,515822
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,522346
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,528010
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,532307
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,534104
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,537229
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,539378
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,541761
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,544300
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,546683
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,548870
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,551097
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,554535
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,558246
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,561957
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,567426
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,573989
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,584692
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,599419
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,615944
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,639460
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,696254
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,627683
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,636167
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,649215
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,658183
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,668385
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,674238
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,677192
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,681434
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,684871
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,688791
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,693355
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,696254
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,699369
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,704094
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,709249
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,714189
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,719881
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,728580
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,738461
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,754409
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,776747
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,801072
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,831894
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM15,Free State of Thuringia,observed,NA,9002
+2022-02-07,0 wk ahead inc case,2022-02-05,GM15,Free State of Thuringia,observed,NA,15038
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,point,NA,22024
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,17386
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,18048
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,18605
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,19215
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,19709
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,20102
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,20511
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,20794
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,21052
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,21401
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,21725
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,22024
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,22400
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,22749
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,23188
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,23562
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,23894
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,24416
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,24973
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,25682
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,26852
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,27922
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,29490
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,point,NA,28781
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,20083
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,21152
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,22167
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,23220
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,24177
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,24910
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,25596
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,26234
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,26835
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,27473
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,28036
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,28781
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,29344
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,30056
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,30987
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,31704
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,32513
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,33395
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,34575
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,36106
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,38419
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,40466
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,43725
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,point,NA,34347
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,22125
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,23584
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,24835
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,26340
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,27786
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,28764
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,29780
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,30738
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,31676
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,32445
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,33279
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,34347
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,35181
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,36165
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,37351
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,38387
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,39449
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,40733
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,42309
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,44466
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,47333
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,49782
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,53255
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,point,NA,36833
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,23124
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,24745
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,26366
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,27939
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,29641
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,30873
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,31992
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,33105
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,34029
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,34807
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,35790
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,36833
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,37865
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,38714
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,39800
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,40934
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,42004
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,43350
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,44706
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,46398
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,48797
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,51104
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,53336
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM15,Free State of Thuringia,observed,NA,318172
 2022-02-07,0 wk ahead cum case,2022-02-05,GM15,Free State of Thuringia,observed,NA,333210
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,point,NA,270796
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,270774
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,270775
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,270776
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,270778
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,270781
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,270783
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,270785
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,270787
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,270789
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,270792
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,270794
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,270796
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,270798
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,270801
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,270803
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,270805
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,270807
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,270809
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,270811
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,270814
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,270816
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,270817
-2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,270818
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,point,NA,270797
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,270774
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,270775
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,270776
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,270779
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,270781
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,270783
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,270786
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,270788
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,270790
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,270793
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,270795
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,270797
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,270800
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,270802
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,270804
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,270807
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,270809
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,270811
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,270813
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,270816
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,270818
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,270819
-2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,270820
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,point,NA,270798
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,270774
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,270775
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,270777
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,270779
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,270781
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,270784
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,270786
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,270788
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,270791
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,270793
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,270795
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,270798
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,270800
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,270802
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,270805
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,270807
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,270809
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,270812
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,270814
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,270816
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,270819
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,270820
-2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,270821
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,point,NA,270798
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,270774
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,270775
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,270777
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,270779
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,270781
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,270784
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,270786
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,270788
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,270791
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,270793
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,270796
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,270798
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,270800
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,270803
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,270805
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,270807
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,270810
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,270812
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,270814
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,270817
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,270819
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,270820
-2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,270821
-2022-02-07,-1 wk ahead inc case,2022-01-28,GM16,Berlin State,observed,NA,74239
-2022-02-07,0 wk ahead inc case,2022-02-05,GM16,Berlin State,observed,NA,82107
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,point,NA,68776
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.010,47575
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.025,50421
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.050,53021
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.100,56100
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.150,58273
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.200,59954
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.250,61714
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.300,63279
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.350,64585
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.400,65892
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.450,67289
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.500,68776
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.550,70484
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.600,72010
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.650,73795
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.700,75593
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.750,77611
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.800,79978
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.850,83109
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.900,86717
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.950,92836
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.975,98993
-2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.990,106884
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,point,NA,60824
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.010,34801
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.025,37926
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.050,40865
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.100,44455
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.150,46929
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.200,49142
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.250,51207
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.300,53216
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.350,55039
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.400,56843
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.450,58555
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.500,60824
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.550,62870
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.600,65121
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.650,67743
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.700,70310
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.750,73175
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.800,76746
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.850,81192
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.900,86530
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.950,95943
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.975,105169
-2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.990,117278
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,point,NA,52695
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.010,25399
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.025,28413
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.050,31281
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.100,34840
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.150,37331
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.200,39696
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.250,42019
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.300,44113
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.350,46038
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.400,48215
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.450,50099
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.500,52695
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.550,54830
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.600,57488
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.650,60544
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.700,63579
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.750,66719
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.800,71178
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.850,76097
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.900,82565
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.950,93617
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.975,104585
-2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.990,117940
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,point,NA,44533
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.010,18627
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.025,21155
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.050,23859
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.100,27048
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.150,29363
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.200,31833
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.250,33992
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.300,35917
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.350,37959
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.400,40099
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.450,42180
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.500,44533
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.550,46692
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.600,49629
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.650,52682
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.700,55911
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.750,59236
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.800,63457
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.850,68591
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.900,75029
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.950,86484
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.975,96928
-2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.990,109609
-2022-02-07,-1 wk ahead cum case,2022-01-28,GM16,Berlin State,observed,NA,511801
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,point,NA,356852
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,351341
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,352133
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,352823
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,353651
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,354206
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,354690
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,355126
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,355492
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,355816
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,356111
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,356483
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,356852
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,357295
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,357693
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,358161
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,358610
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,359021
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,359544
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,360112
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,360923
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,362242
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,363403
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,365094
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,point,NA,385611
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,371562
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,373361
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,375125
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,376873
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,378392
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,379647
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,380860
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,381768
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,382608
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,383609
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,384636
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,385611
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,386714
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,387766
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,389073
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,390235
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,391465
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,392865
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,394757
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,396844
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,400637
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,403886
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,408773
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,point,NA,420017
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,393694
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,397097
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,400171
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,403275
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,406259
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,408393
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,410601
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,412541
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,414317
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,415974
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,417854
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,420017
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,421540
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,423927
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,426270
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,428643
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,430791
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,433552
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,437074
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,441267
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,447848
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,453444
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,461994
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,point,NA,456759
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,416837
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,421804
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,426285
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,431313
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,436078
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,439302
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,442444
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,445425
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,448385
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,451001
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,453616
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,456759
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,459374
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,462821
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,466309
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,469553
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,472837
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,476852
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,481637
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,487902
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,496884
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,504244
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,514219
+2022-02-07,-1 wk ahead inc case,2022-01-29,GM16,Berlin State,observed,NA,72915
+2022-02-07,0 wk ahead inc case,2022-02-05,GM16,Berlin State,observed,NA,69345
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,point,NA,52418
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.010,37605
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.025,39481
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.050,41525
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.100,43870
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.150,45303
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.200,46312
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.250,47551
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.300,48569
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.350,49613
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.400,50515
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.450,51498
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.500,52418
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.550,53391
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.600,54285
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.650,55347
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.700,56542
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.750,57851
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.800,59294
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.850,61240
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.900,63382
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.950,66842
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.975,70328
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.990,74947
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,point,NA,40795
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.010,24641
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.025,26591
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.050,28638
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.100,31031
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.150,32526
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.200,33879
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.250,35159
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.300,36272
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.350,37396
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.400,38509
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.450,39754
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.500,40795
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.550,41860
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.600,42961
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.650,44372
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.700,45844
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.750,47519
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.800,49338
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.850,51827
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.900,54663
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.950,59701
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.975,64774
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.990,71463
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,point,NA,31421
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.010,16151
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.025,17949
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.050,19760
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.100,21948
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.150,23330
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.200,24658
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.250,25879
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.300,27047
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.350,28053
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.400,29167
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.450,30254
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.500,31421
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.550,32508
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.600,33608
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.650,35259
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.700,36762
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.750,38466
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.800,40492
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.850,43028
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.900,46450
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.950,52046
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.975,57963
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.990,65921
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,point,NA,24085
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.010,10641
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.025,12095
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.050,13628
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.100,15479
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.150,16656
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.200,17912
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.250,18903
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.300,19987
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.350,20952
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.400,21983
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.450,22988
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.500,24085
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.550,25050
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.600,26121
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.650,27694
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.700,29162
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.750,30880
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.800,32810
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.850,35362
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.900,38825
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.950,44589
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.975,50776
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.990,59051
+2022-02-07,-1 wk ahead cum case,2022-01-29,GM16,Berlin State,observed,NA,524563
 2022-02-07,0 wk ahead cum case,2022-02-05,GM16,Berlin State,observed,NA,593908
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,point,NA,664036
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.010,634564
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.025,639264
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.050,642609
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.100,647025
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.150,650086
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.200,652511
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.250,654836
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.300,656626
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.350,658533
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.400,660289
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.450,662045
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.500,664036
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.550,666026
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.600,667966
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.650,670191
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.700,672449
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.750,674891
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.800,677852
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.850,681498
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.900,685863
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.950,693273
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.975,700532
-2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.990,709782
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,point,NA,724710
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.010,670198
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.025,677720
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.050,684018
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.100,691751
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.150,697209
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.200,701757
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.250,705956
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.300,710330
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.350,713759
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.400,717362
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.450,720721
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.500,724710
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.550,728559
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.600,733142
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.650,737551
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.700,742484
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.750,747767
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.800,754310
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.850,762777
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.900,772154
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.950,788704
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.975,805148
-2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.990,826456
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,point,NA,777421
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.010,696004
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.025,706236
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.050,715413
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.100,726869
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.150,734432
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.200,741495
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.250,747891
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.300,754787
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.350,759736
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.400,765353
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.450,770692
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.500,777421
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.550,783761
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.600,790546
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.650,798109
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.700,806062
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.750,814738
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.800,825026
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.850,838707
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.900,854001
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.950,881529
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.975,908780
-2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.990,944038
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,point,NA,822115
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.010,714644
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.025,727658
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.050,739324
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.100,754207
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.150,764229
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.200,773727
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.250,781879
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.300,790629
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.350,797883
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.400,805213
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.450,813065
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.500,822115
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.550,830790
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.600,839914
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.650,851432
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.700,861827
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.750,873569
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.800,888377
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.850,907672
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.900,928912
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.950,968101
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.975,1005570
-2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.990,1052761
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,point,NA,647286
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.010,626100
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.025,628918
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.050,632023
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.100,635618
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.150,637696
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.200,639177
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.250,640610
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.300,642019
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.350,643440
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.400,644682
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.450,645888
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.500,647286
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.550,648528
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.600,649913
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.650,651071
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.700,652636
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.750,654260
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.800,656278
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.850,658547
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.900,661509
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.950,665724
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.975,669916
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.990,675230
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,point,NA,688155
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.010,651064
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.025,655975
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.050,661148
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.100,666964
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.150,670444
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.200,672947
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.250,675855
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.300,678334
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.350,681147
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.400,683054
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.450,685772
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.500,688155
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.550,690396
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.600,692875
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.650,695307
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.700,698525
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.750,701552
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.800,705581
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.850,710110
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.900,715878
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.950,724865
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.975,734209
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.990,745890
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,point,NA,719639
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.010,667395
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.025,674158
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.050,680957
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.100,689169
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.150,694000
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.200,697381
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.250,701803
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.300,705222
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.350,709160
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.400,712096
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.450,716109
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.500,719639
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.550,722872
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.600,726328
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.650,730489
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.700,735208
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.750,739965
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.800,745761
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.850,753639
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.900,761851
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.950,776825
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.975,791874
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.990,811643
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,point,NA,743666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.010,678483
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.025,686140
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.050,694552
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.100,704677
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.150,710823
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.200,715558
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.250,720847
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.300,725381
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.350,730166
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.400,734196
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.450,739183
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.500,743666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.550,747948
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.600,752482
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.650,758073
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.700,764421
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.750,770768
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.800,778424
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.850,789154
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.900,800287
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.950,821091
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.975,842702
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.990,870760

--- a/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger-case.csv
+++ b/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger-case.csv
@@ -1,0 +1,3333 @@
+forecast_date,target,target_end_date,location,location_name,type,quantile,value
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM,Germany,observed,NA,968533
+2022-02-07,0 wk ahead inc case,2022-02-05,GM,Germany,observed,NA,1460338
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,point,NA,2013058
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.010,1730383
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.025,1771270
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.050,1800223
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.100,1836911
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.150,1861001
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.200,1884207
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.250,1908740
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.300,1929736
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.350,1951616
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.400,1967087
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.450,1992282
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.500,2013058
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.550,2034938
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.600,2062122
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.650,2084003
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.700,2109198
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.750,2143013
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.800,2178154
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.850,2228324
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.900,2286450
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.950,2379717
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.975,2477846
+2022-02-07,1 wk ahead inc case,2022-02-12,GM,Germany,quantile,0.990,2617526
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,point,NA,2569682
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.010,2086304
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.025,2157472
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.050,2202251
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.100,2253827
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.150,2299806
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.200,2342186
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.250,2378570
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.300,2416152
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.350,2454934
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.400,2487320
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.450,2521704
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.500,2569682
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.550,2616460
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.600,2663238
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.650,2710017
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.700,2757595
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.750,2823964
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.800,2887135
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.850,2987889
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.900,3097039
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.950,3278155
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.975,3464869
+2022-02-07,2 wk ahead inc case,2022-02-19,GM,Germany,quantile,0.990,3742341
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,point,NA,2994586
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.010,2359135
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.025,2443861
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.050,2506243
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.100,2577469
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.150,2631471
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.200,2693852
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.250,2736216
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.300,2786959
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.350,2839564
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.400,2880996
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.450,2928946
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.500,2994586
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.550,3059295
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.600,3120745
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.650,3183127
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.700,3245508
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.750,3326511
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.800,3416358
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.850,3538793
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.900,3687298
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.950,3913547
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.975,4120709
+2022-02-07,3 wk ahead inc case,2022-02-26,GM,Germany,quantile,0.990,4429357
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,point,NA,3139223
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.010,2479073
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.025,2576503
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.050,2643185
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.100,2709496
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.150,2769139
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.200,2827671
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.250,2874348
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.300,2931768
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.350,2987337
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.400,3026605
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.450,3084766
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.500,3139223
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.550,3204423
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.600,3270364
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.650,3332600
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.700,3392984
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.750,3465593
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.800,3543018
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.850,3646745
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.900,3779738
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.950,3958297
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.975,4094624
+2022-02-07,4 wk ahead inc case,2022-03-05,GM,Germany,quantile,0.990,4294299
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM,Germany,observed,NA,9429079
+2022-02-07,0 wk ahead cum case,2022-02-05,GM,Germany,observed,NA,10889417
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,point,NA,13032834
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.010,12638791
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.025,12712590
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.050,12748950
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.100,12806589
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.150,12834870
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.200,12867460
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.250,12905706
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.300,12933986
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.350,12953917
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.400,12978158
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.450,13007516
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.500,13032834
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.550,13060576
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.600,13084547
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.650,13108788
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.700,13139223
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.750,13178008
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.800,13225411
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.850,13276586
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.900,13347691
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.950,13448155
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.975,13554544
+2022-02-07,1 wk ahead cum case,2022-02-12,GM,Germany,quantile,0.990,13709145
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,point,NA,15603498
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.010,14733815
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.025,14858055
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.050,14951069
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.100,15065344
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.150,15141749
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.200,15211509
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.250,15282599
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.300,15350366
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.350,15417469
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.400,15460655
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.450,15540381
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.500,15603498
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.550,15665286
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.600,15750992
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.650,15819424
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.700,15886527
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.750,15991500
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.800,16102453
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.850,16256591
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.900,16434647
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.950,16714354
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.975,17013992
+2022-02-07,2 wk ahead cum case,2022-02-19,GM,Germany,quantile,0.990,17433221
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,point,NA,18591421
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.010,17103992
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.025,17330658
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.050,17458088
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.100,17638519
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.150,17779481
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.200,17901272
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.250,18016297
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.300,18136960
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.350,18258751
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.400,18348967
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.450,18461736
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.500,18591421
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.550,18730127
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.600,18874472
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.650,19004157
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.700,19140608
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.750,19322167
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.800,19503726
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.850,19799182
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.900,20119447
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.950,20619016
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.975,21127606
+2022-02-07,3 wk ahead cum case,2022-02-26,GM,Germany,quantile,0.990,21874140
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,point,NA,21740940
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.010,19583911
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.025,19909697
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.050,20101598
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.100,20345566
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.150,20556806
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.200,20745732
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.250,20894492
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.300,21068542
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.350,21229204
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.400,21370526
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.450,21544576
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.500,21740940
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.550,21934329
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.600,22132181
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.650,22334495
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.700,22538297
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.750,22773339
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.800,23050034
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.850,23466564
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.900,23906895
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.950,24594169
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.975,25227890
+2022-02-07,4 wk ahead cum case,2022-03-05,GM,Germany,quantile,0.990,26133842
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM01,Baden-Württemberg State,observed,NA,120967
+2022-02-07,0 wk ahead inc case,2022-02-05,GM01,Baden-Württemberg State,observed,NA,195800
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,point,NA,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,1
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,1
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,2
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,2
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,4
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,4
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,6
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,6
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,7
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,7
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,8
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,8
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,9
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,9
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,9
+2022-02-07,1 wk ahead inc case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,9
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,point,NA,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,3
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,3
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,3
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,3
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,3
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,3
+2022-02-07,2 wk ahead inc case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,3
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,point,NA,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,1
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,point,NA,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,0
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM01,Baden-Württemberg State,observed,NA,1301970
+2022-02-07,0 wk ahead cum case,2022-02-05,GM01,Baden-Württemberg State,observed,NA,1497770
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,point,NA,960070
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,960033
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,960034
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,960036
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,960040
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,960044
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,960047
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,960051
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,960055
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,960059
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,960062
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,960066
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,960070
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,960074
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,960077
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,960081
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,960085
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,960089
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,960093
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,960096
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,960100
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,960104
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,960106
+2022-02-07,1 wk ahead cum case,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,960107
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,point,NA,960072
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,960033
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,960034
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,960036
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,960040
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,960044
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,960048
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,960052
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,960056
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,960060
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,960064
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,960068
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,960072
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,960076
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,960080
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,960084
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,960087
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,960091
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,960095
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,960099
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,960103
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,960107
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,960109
+2022-02-07,2 wk ahead cum case,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,960110
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,point,NA,960072
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,960033
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,960035
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,960037
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,960040
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,960044
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,960048
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,960052
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,960056
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,960060
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,960064
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,960068
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,960072
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,960076
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,960080
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,960084
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,960088
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,960092
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,960096
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,960100
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,960104
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,960108
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,960110
+2022-02-07,3 wk ahead cum case,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,960112
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,point,NA,960073
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,960033
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,960035
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,960037
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,960041
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,960044
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,960049
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,960053
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,960056
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,960061
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,960065
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,960069
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,960073
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,960077
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,960081
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,960085
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,960089
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,960093
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,960097
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,960101
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,960105
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,960109
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,960111
+2022-02-07,4 wk ahead cum case,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,960112
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM02,Free State of Bavaria,observed,NA,169759
+2022-02-07,0 wk ahead inc case,2022-02-05,GM02,Free State of Bavaria,observed,NA,277046
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,point,NA,415267
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,311904
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,325624
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,339878
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,357622
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,368094
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,376870
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,385305
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,391269
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,397571
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,404068
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,409789
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,415267
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,421376
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,427436
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,432527
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,439750
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,448865
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,458222
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,466512
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,478681
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,499189
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,520376
+2022-02-07,1 wk ahead inc case,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,545150
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,point,NA,565284
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,372306
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,396854
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,423499
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,455996
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,475128
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,491727
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,507539
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,519070
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,531475
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,542832
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,553490
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,565284
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,575767
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,587560
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,597782
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,611148
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,626872
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,642772
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,660506
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,684180
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,719911
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,755466
+2022-02-07,2 wk ahead inc case,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,796613
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,point,NA,670162
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,417165
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,450950
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,485914
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,530503
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,556333
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,576565
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,596699
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,614181
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,628913
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,641484
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,657591
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,670162
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,681751
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,694028
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,709939
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,725653
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,741072
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,757474
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,777804
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,801866
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,835259
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,868848
+2022-02-07,3 wk ahead inc case,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,914124
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,point,NA,675011
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,436397
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,473974
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,510954
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,556526
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,582001
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,601425
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,620027
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,636537
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,647295
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,655961
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,664777
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,675011
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,684275
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,693091
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,702877
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,712888
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,723721
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,736869
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,753006
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,769591
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,806123
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,829506
+2022-02-07,4 wk ahead inc case,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,860211
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM02,Free State of Bavaria,observed,NA,1699836
+2022-02-07,0 wk ahead cum case,2022-02-05,GM02,Free State of Bavaria,observed,NA,1976882
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,point,NA,2417123
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,2295996
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,2314262
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,2330702
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,2351308
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,2363695
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,2374997
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,2384130
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,2390466
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,2396916
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,2405307
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,2411187
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,2417123
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,2424030
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,2430823
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,2436017
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,2444408
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,2455025
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,2465186
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,2476374
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,2488703
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,2510965
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,2535225
+2022-02-07,1 wk ahead cum case,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,2561996
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,point,NA,2982857
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,2671858
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,2712787
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,2754003
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,2807902
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,2840040
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,2866989
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,2890912
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,2910512
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,2928670
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,2947838
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,2965852
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,2982857
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,2998854
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,3018021
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,3033586
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,3055491
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,3081144
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,3108093
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,3135187
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,3170927
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,3230879
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,3290542
+2022-02-07,2 wk ahead cum case,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,3356547
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,point,NA,3654293
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,3087646
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,3163006
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,3242955
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,3338121
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,3394882
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,3443431
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,3487874
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,3524105
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,3556471
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,3589561
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,3622652
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,3654293
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,3681346
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,3712746
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,3745112
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,3781101
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,3822887
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,3867330
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,3915154
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,3973365
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,4069738
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,4154518
+2022-02-07,3 wk ahead cum case,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,4258138
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,point,NA,4333150
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,3523894
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,3635732
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,3751654
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,3895536
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,3979415
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,4044758
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,4107903
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,4161623
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,4205604
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,4247073
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,4293567
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,4333150
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,4369592
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,4408861
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,4460068
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,4504049
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,4550858
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,4606463
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,4661754
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,4738407
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,4843962
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,4943549
+2022-02-07,4 wk ahead cum case,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,5087430
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,11019
+2022-02-07,0 wk ahead inc case,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,10699
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,10595
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,9102
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,9433
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,9557
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,9781
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,9919
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,10003
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,10064
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,10156
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,10296
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,10377
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,10489
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,10595
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,10671
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,10796
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,10897
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,11028
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,11156
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,11337
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,11579
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,11940
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,12488
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,13024
+2022-02-07,1 wk ahead inc case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,13748
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,9986
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,7991
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,8432
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,8615
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,8875
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,9018
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,9166
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,9228
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,9381
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,9549
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,9663
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,9830
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,9986
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,10110
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,10237
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,10391
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,10574
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,10778
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,11005
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,11406
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,11957
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,12845
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,13742
+2022-02-07,2 wk ahead inc case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,14979
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,9275
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,6968
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,7462
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,7645
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,7965
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,8126
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,8270
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,8343
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,8548
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,8741
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,8861
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,9061
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,9275
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,9397
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,9546
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,9697
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,9960
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,10215
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,10493
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,11030
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,11715
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,12884
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,14035
+2022-02-07,3 wk ahead inc case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,15725
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,8445
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,6038
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,6540
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,6712
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,7056
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,7255
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,7368
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,7477
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,7691
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,7878
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,8024
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,8249
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,8445
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,8599
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,8768
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,8932
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,9240
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,9499
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,9837
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,10472
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,11220
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,12597
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,13933
+2022-02-07,4 wk ahead inc case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,15862
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,83082
+2022-02-07,0 wk ahead cum case,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,93781
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,105287
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,102837
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,103345
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,103707
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,103975
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,104288
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,104493
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,104617
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,104732
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,104853
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,104993
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,105131
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,105287
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,105417
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,105614
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,105755
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,105949
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,106124
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,106349
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,106659
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,107078
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,107778
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,108387
+2022-02-07,1 wk ahead cum case,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,109296
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,115319
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,110938
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,111796
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,112338
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,112906
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,113372
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,113643
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,113882
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,114120
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,114421
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,114663
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,114978
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,115319
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,115524
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,115784
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,116202
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,116492
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,116873
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,117350
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,118017
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,119025
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,120587
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,122024
+2022-02-07,2 wk ahead cum case,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,124121
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,124578
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,118050
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,119373
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,119998
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,120996
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,121502
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,121976
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,122226
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,122581
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,123187
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,123474
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,123985
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,124578
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,124928
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,125377
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,125920
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,126444
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,127081
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,127817
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,128953
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,130726
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,133459
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,136080
+2022-02-07,3 wk ahead cum case,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,139775
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,133012
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,124088
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,126014
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,126684
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,128023
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,128683
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,129334
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,129637
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,130260
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,131022
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,131554
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,132214
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,133012
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,133590
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,134131
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,134855
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,135681
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,136552
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,137616
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,139395
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,141945
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,145971
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,149997
+2022-02-07,4 wk ahead cum case,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,155720
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,40461
+2022-02-07,0 wk ahead inc case,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,44630
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,49462
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,33527
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,35858
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,37838
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,40221
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,41845
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,43319
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,44414
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,45523
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,46670
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,47616
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,48502
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,49462
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,50564
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,51443
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,52352
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,53387
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,54451
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,55792
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,57348
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,59671
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,62896
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,66090
+2022-02-07,1 wk ahead inc case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,70163
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,53368
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,29572
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,32639
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,35432
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,39055
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,41458
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,43672
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,45412
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,47046
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,48869
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,50278
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,51734
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,53368
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,55025
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,56481
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,57926
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,59690
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,61418
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,63703
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,66142
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,70048
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,75648
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,80632
+2022-02-07,2 wk ahead inc case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,87332
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,54806
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,25638
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,29150
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,32606
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,36829
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,39867
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,42584
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,44731
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,46737
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,49023
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,50834
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,52590
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,54806
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,56799
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,58694
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,60450
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,62596
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,64882
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,67822
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,70819
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,75334
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,82121
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,87862
+2022-02-07,3 wk ahead inc case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,95081
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,53534
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,21944
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,25578
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,29278
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,33887
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,37219
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,40182
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,42446
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,44790
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,47134
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,49136
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,51085
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,53534
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,55654
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,57511
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,59434
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,61712
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,63871
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,66808
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,69981
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,74195
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,80279
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,85520
+2022-02-07,4 wk ahead inc case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,91511
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,233883
+2022-02-07,0 wk ahead cum case,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,278513
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,332344
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,312477
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,315658
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,318206
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,321062
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,323099
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,324754
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,326298
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,327600
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,328921
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,330149
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,331209
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,332344
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,333497
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,334567
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,335850
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,336966
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,338110
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,339738
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,341617
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,344240
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,348155
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,351876
+2022-02-07,1 wk ahead cum case,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,356452
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,385592
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,342305
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,348552
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,353876
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,360312
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,364630
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,368571
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,371820
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,374859
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,377731
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,380456
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,383035
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,385592
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,388611
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,391021
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,393620
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,396450
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,399469
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,403368
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,407686
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,414247
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,423491
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,432400
+2022-02-07,2 wk ahead cum case,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,443552
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,440210
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,368291
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,378052
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,386663
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,397261
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,404547
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,411415
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,416539
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,421699
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,427067
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,431495
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,435574
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,440210
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,445509
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,449692
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,454050
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,459175
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,464474
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,470993
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,478418
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,489679
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,505436
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,520217
+2022-02-07,3 wk ahead cum case,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,538798
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,493828
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,390281
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,403763
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,416049
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,431442
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,441481
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,451520
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,458883
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,466340
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,474372
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,480347
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,486658
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,493828
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,501143
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,507357
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,513237
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,520743
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,528344
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,537714
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,548279
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,563625
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,586332
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,605407
+2022-02-07,4 wk ahead cum case,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,628831
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM05,Hesse State,observed,NA,84215
+2022-02-07,0 wk ahead inc case,2022-02-05,GM05,Hesse State,observed,NA,124253
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,point,NA,174011
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.010,148832
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.025,152397
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.050,156023
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.100,159208
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.150,161251
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.200,162894
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.250,165458
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.300,167821
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.350,169544
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.400,170826
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.450,172629
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.500,174011
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.550,175994
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.600,178138
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.650,180401
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.700,182524
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.750,185890
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.800,188974
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.850,192921
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.900,199391
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.950,207884
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.975,216778
+2022-02-07,1 wk ahead inc case,2022-02-12,GM05,Hesse State,quantile,0.990,229077
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,point,NA,225662
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.010,182149
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.025,187212
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.050,193569
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.100,198480
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.150,202059
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.200,205561
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.250,209825
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.300,213784
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.350,216830
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.400,219419
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.450,222845
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.500,225662
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.550,229621
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.600,233200
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.650,238301
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.700,242603
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.750,249151
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.800,255090
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.850,263008
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.900,276333
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.950,294339
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.975,311623
+2022-02-07,2 wk ahead inc case,2022-02-19,GM05,Hesse State,quantile,0.990,336825
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,point,NA,270817
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.010,210733
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.025,216942
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.050,226303
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.100,231605
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.150,237336
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.200,241873
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.250,247939
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.300,253670
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.350,257682
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.400,262076
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.450,266948
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.500,270817
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.550,276070
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.600,280655
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.650,288393
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.700,295652
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.750,303628
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.800,312560
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.850,322780
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.900,341646
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.950,366147
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.975,389216
+2022-02-07,3 wk ahead inc case,2022-02-26,GM05,Hesse State,quantile,0.990,420356
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,point,NA,296249
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.010,228847
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.025,235942
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.050,245553
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.100,251699
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.150,258546
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.200,263538
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.250,270921
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.300,276614
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.350,281605
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.400,286720
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.450,291876
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.500,296249
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.550,301364
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.600,306891
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.650,315223
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.700,323102
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.750,330775
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.800,340633
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.850,351317
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.900,368518
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.950,390545
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.975,409974
+2022-02-07,4 wk ahead inc case,2022-03-05,GM05,Hesse State,quantile,0.990,431300
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM05,Hesse State,observed,NA,672879
+2022-02-07,0 wk ahead cum case,2022-02-05,GM05,Hesse State,observed,NA,797132
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,point,NA,983109
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.010,948555
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.025,954314
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.050,958736
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.100,963742
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.150,966925
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.200,969185
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.250,972028
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.300,975430
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.350,977326
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.400,979367
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.450,981238
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.500,983109
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.550,985758
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.600,988577
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.650,990642
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.700,993169
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.750,996693
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.800,1000557
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.850,1005101
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.900,1012415
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.950,1021430
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.975,1031928
+2022-02-07,1 wk ahead cum case,2022-02-12,GM05,Hesse State,quantile,0.990,1045390
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,point,NA,1208457
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.010,1130285
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.025,1141859
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.050,1152443
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.100,1162717
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.150,1169649
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.200,1174787
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.250,1182400
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.300,1189455
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.350,1194593
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.400,1199358
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.450,1204557
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.500,1208457
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.550,1214770
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.600,1221454
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.650,1228696
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.700,1235752
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.750,1245717
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.800,1255558
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.850,1267627
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.900,1288114
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.950,1315099
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.975,1342766
+2022-02-07,2 wk ahead cum case,2022-02-19,GM05,Hesse State,quantile,0.990,1381264
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,point,NA,1479846
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.010,1341643
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.025,1357606
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.050,1378599
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.100,1396421
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.150,1407027
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.200,1416977
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.250,1430972
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.300,1442452
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.350,1453495
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.400,1460712
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.450,1470224
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.500,1479846
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.550,1491545
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.600,1502260
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.650,1517021
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.700,1529048
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.750,1549822
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.800,1566769
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.850,1591589
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.900,1629420
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.950,1681902
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.975,1731323
+2022-02-07,3 wk ahead cum case,2022-02-26,GM05,Hesse State,quantile,0.990,1799440
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,point,NA,1775069
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.010,1570051
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.025,1595171
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.050,1624351
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.100,1648569
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.150,1665716
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.200,1681660
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.250,1701666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.300,1719415
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.350,1734306
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.400,1746941
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.450,1762434
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.500,1775069
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.550,1794022
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.600,1808612
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.650,1831927
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.700,1851782
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.750,1879609
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.800,1907436
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.850,1942182
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.900,1999792
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.950,2073045
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.975,2141184
+2022-02-07,4 wk ahead cum case,2022-03-05,GM05,Hesse State,quantile,0.990,2233088
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM06,Lower Saxony State,observed,NA,72954
+2022-02-07,0 wk ahead inc case,2022-02-05,GM06,Lower Saxony State,observed,NA,111817
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,point,NA,147298
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.010,103901
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.025,111533
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.050,117355
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.100,124259
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.150,128750
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.200,132181
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.250,134843
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.300,137671
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.350,140416
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.400,143389
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.450,145406
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.500,147298
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.550,149399
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.600,151852
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.650,154202
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.700,156781
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.750,160357
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.800,163331
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.850,167573
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.900,172355
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.950,181214
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.975,188783
+2022-02-07,1 wk ahead inc case,2022-02-12,GM06,Lower Saxony State,quantile,0.990,198618
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,point,NA,188752
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.010,110034
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.025,122832
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.050,133110
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.100,146144
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.150,153823
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.200,160439
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.250,165321
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.300,170204
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.350,175757
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.400,181230
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.450,185286
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.500,188752
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.550,192965
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.600,197809
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.650,202219
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.700,207732
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.750,213836
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.800,220215
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.850,227382
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.900,237778
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.950,255104
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.975,270265
+2022-02-07,2 wk ahead inc case,2022-02-19,GM06,Lower Saxony State,quantile,0.990,289127
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,point,NA,223804
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.010,113204
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.025,130711
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.050,145126
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.100,163629
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.150,174270
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.200,184124
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.250,191306
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.300,198330
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.350,205511
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.400,212692
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.450,218825
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.500,223804
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.550,230723
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.600,236070
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.650,242570
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.700,250432
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.750,258452
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.800,268149
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.850,278056
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.900,291528
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.950,314119
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.975,334038
+2022-02-07,3 wk ahead inc case,2022-02-26,GM06,Lower Saxony State,quantile,0.990,356840
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,point,NA,244513
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.010,113074
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.025,134649
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.050,152195
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.100,173718
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.150,186725
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.200,198048
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.250,206872
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.300,214981
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.350,224621
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.400,230283
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.450,237780
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.500,244513
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.550,250481
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.600,257111
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.650,263436
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.700,271596
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.750,280369
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.800,289295
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.850,299445
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.900,312808
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.950,332037
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.975,351827
+2022-02-07,4 wk ahead inc case,2022-03-05,GM06,Lower Saxony State,quantile,0.990,376717
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM06,Lower Saxony State,observed,NA,616518
+2022-02-07,0 wk ahead cum case,2022-02-05,GM06,Lower Saxony State,observed,NA,728335
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,point,NA,883428
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.010,832829
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.025,842022
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.050,848695
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.100,856640
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.150,862257
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.200,866073
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.250,869338
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.300,872338
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.350,875315
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.400,878507
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.450,881459
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.500,883428
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.550,885876
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.600,888564
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.650,891373
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.700,894325
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.750,897782
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.800,901862
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.850,906495
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.900,912016
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.950,921329
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.975,930018
+2022-02-07,1 wk ahead cum case,2022-02-12,GM06,Lower Saxony State,quantile,0.990,941156
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,point,NA,1071827
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.010,943454
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.025,965499
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.050,982016
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.100,1002930
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.150,1016182
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.200,1026230
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.250,1034898
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.300,1043313
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.350,1051227
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.400,1060710
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.450,1066802
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.500,1071827
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.550,1078609
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.600,1085958
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.650,1093934
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.700,1101533
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.750,1110703
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.800,1122007
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.850,1134505
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.900,1149579
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.950,1176019
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.975,1199257
+2022-02-07,2 wk ahead cum case,2022-02-19,GM06,Lower Saxony State,quantile,0.990,1228649
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,point,NA,1295099
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.010,1057627
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.025,1097148
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.050,1127221
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.100,1166627
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.150,1190593
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.200,1210987
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.250,1226197
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.300,1241291
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.350,1257307
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.400,1274475
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.450,1285651
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.500,1295099
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.550,1309041
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.600,1322753
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.650,1336695
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.700,1352941
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.750,1369878
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.800,1390503
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.850,1411358
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.900,1440164
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.950,1489479
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.975,1533494
+2022-02-07,3 wk ahead cum case,2022-02-26,GM06,Lower Saxony State,quantile,0.990,1584767
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,point,NA,1537559
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.010,1171030
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.025,1231536
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.050,1280075
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.100,1341412
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.150,1376818
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.200,1409066
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.250,1434333
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.300,1456607
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.350,1479713
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.400,1505311
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.450,1524095
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.500,1537559
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.550,1561164
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.600,1576456
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.650,1598398
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.700,1624496
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.750,1649430
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.800,1681013
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.850,1710435
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.900,1754485
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.950,1822305
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.975,1882313
+2022-02-07,4 wk ahead cum case,2022-03-05,GM06,Lower Saxony State,quantile,0.990,1954123
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,219290
+2022-02-07,0 wk ahead inc case,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,344417
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,267497
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,193630
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,206705
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,219222
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,229458
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,236159
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,244953
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,248140
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,252119
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,255911
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,260425
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,264822
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,267497
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,272848
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,277152
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,280572
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,283457
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,289692
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,296905
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,299604
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,302326
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,308793
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,312469
+2022-02-07,1 wk ahead inc case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,317402
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,152728
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,93723
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,104514
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,112187
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,119512
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,125708
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,129442
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,132909
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,135740
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,139331
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,143926
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,147004
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,152728
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,155580
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,158862
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,165304
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,173039
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,177266
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,185267
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,188529
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,197372
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,206768
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,215303
+2022-02-07,2 wk ahead inc case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,220350
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,72765
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,40845
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,46861
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,50675
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,53947
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,57662
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,59448
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,61534
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,63249
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,65492
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,66721
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,69850
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,72765
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,75351
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,78151
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,82309
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,86124
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,90353
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,97040
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,101198
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,110056
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,120072
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,126445
+2022-02-07,3 wk ahead inc case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,136275
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,31933
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,16807
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,19514
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,21077
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,22667
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,24426
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,25188
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,26109
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,27309
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,28184
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,28798
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,30482
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,31933
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,33384
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,34965
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,37533
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,39375
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,42547
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,45980
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,49784
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,54185
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,63692
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,67162
+2022-02-07,4 wk ahead inc case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,76771
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,1874915
+2022-02-07,0 wk ahead cum case,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,2219332
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,2513186
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,2419324
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,2437082
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,2452303
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,2468234
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,2474897
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,2482744
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,2489915
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,2495902
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,2499385
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,2504594
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,2508484
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,2513186
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,2518022
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,2522386
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,2527561
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,2532668
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,2536592
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,2541158
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,2545014
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,2549141
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,2559322
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,2570619
+2022-02-07,1 wk ahead cum case,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,2572006
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,2664799
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,2516040
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,2542216
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,2568285
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,2588466
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,2602009
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,2615070
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,2625026
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,2631236
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,2640604
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,2650614
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,2657840
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,2664799
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,2674488
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,2685247
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,2693170
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,2703233
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,2713939
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,2727589
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,2736903
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,2744826
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,2759172
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,2775873
+2022-02-07,2 wk ahead cum case,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,2785187
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,2739379
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,2556587
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,2589109
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,2618345
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,2643625
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,2659651
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,2677018
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,2687009
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,2697067
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,2705717
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,2721811
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,2729790
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,2739379
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,2749571
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,2763116
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,2775387
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,2791816
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,2805026
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,2820113
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,2835066
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,2850623
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,2881133
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,2888509
+2022-02-07,3 wk ahead cum case,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,2908156
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,2772912
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,2573156
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,2610082
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,2639742
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,2667155
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,2684306
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,2702282
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,2714266
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,2723553
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,2733889
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,2750442
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,2759879
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,2772912
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,2784671
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,2798602
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,2812458
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,2832007
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,2849084
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,2867809
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,2884137
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,2902262
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,2940011
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,2956639
+2022-02-07,4 wk ahead cum case,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,2980457
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,36842
+2022-02-07,0 wk ahead inc case,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,56940
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,73303
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,51308
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,53921
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,56604
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,59628
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,62170
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,64559
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,66383
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,67678
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,69219
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,70514
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,71902
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,73303
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,74856
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,76256
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,77669
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,79293
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,81140
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,83035
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,85659
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,88813
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,94709
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,99569
+2022-02-07,1 wk ahead inc case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,106041
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,94520
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,54277
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,58565
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,62946
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,68655
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,73129
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,77626
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,81028
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,83661
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,86458
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,89184
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,91724
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,94520
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,97852
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,100276
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,103352
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,106567
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,109993
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,114117
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,119687
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,126141
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,138794
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,148838
+2022-02-07,2 wk ahead inc case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,162236
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,114552
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,56281
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,61873
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,68154
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,76277
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,82932
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,89244
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,94587
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,98305
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,102616
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,106803
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,110396
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,114552
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,118989
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,123144
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,127581
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,132299
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,137298
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,143828
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,152233
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,161325
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,178978
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,192070
+2022-02-07,3 wk ahead inc case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,209629
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,129089
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,56910
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,63663
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,71395
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,81815
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,89944
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,98042
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,104184
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,109043
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,114879
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,119371
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,123833
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,129089
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,134009
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,139815
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,144643
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,149869
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,155430
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,163498
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,171504
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,181038
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,196195
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,209427
+2022-02-07,4 wk ahead inc case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,224279
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,365679
+2022-02-07,0 wk ahead cum case,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,422619
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,498307
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,472071
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,475576
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,478900
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,482612
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,485715
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,488292
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,490605
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,492060
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,493639
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,495260
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,496756
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,498307
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,500094
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,501950
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,503419
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,505358
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,507505
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,509763
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,512284
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,516121
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,522341
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,528242
+2022-02-07,1 wk ahead cum case,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,535016
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,592923
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,526806
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,534370
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,542228
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,551194
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,559090
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,566174
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,571745
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,575545
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,580010
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,584437
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,588533
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,592923
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,597351
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,601963
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,606759
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,611408
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,617570
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,623584
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,631885
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,642068
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,660738
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,676566
+2022-02-07,2 wk ahead cum case,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,696932
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,707738
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,583062
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,596802
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,610609
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,627546
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,641829
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,655637
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,666316
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,674070
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,682640
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,690734
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,698896
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,707738
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,717737
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,725423
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,733925
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,743584
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,754670
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,767594
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,783986
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,803303
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,840168
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,868804
+2022-02-07,3 wk ahead cum case,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,906213
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,836766
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,640127
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,660687
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,681930
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,709311
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,732210
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,752868
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,770603
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,782978
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,797009
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,810457
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,822345
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,836766
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,851187
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,864537
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,878959
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,893380
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,909750
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,930701
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,956133
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,985171
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,1038082
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,1078034
+2022-02-07,4 wk ahead cum case,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,1128314
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM09,Saarland State,observed,NA,10474
+2022-02-07,0 wk ahead inc case,2022-02-05,GM09,Saarland State,observed,NA,15892
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,point,NA,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.010,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.025,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.050,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.100,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.150,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.200,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.250,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.300,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.350,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.400,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.450,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.500,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.550,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.600,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.650,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.700,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.750,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.800,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.850,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.900,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.950,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.975,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM09,Saarland State,quantile,0.990,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,point,NA,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.010,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.025,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.050,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.100,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.150,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.200,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.250,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.300,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.350,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.400,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.450,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.500,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.550,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.600,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.650,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.700,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.750,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.800,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.850,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.900,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.950,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.975,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM09,Saarland State,quantile,0.990,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,point,NA,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.010,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.025,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.050,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.100,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.150,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.200,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.250,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.300,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.350,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.400,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.450,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.500,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.550,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.600,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.650,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.700,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.750,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.800,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.850,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.900,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.950,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.975,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM09,Saarland State,quantile,0.990,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,point,NA,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.010,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.025,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.050,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.100,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.150,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.200,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.250,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.300,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.350,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.400,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.450,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.500,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.550,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.600,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.650,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.700,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.750,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.800,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.850,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.900,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.950,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.975,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM09,Saarland State,quantile,0.990,0
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM09,Saarland State,observed,NA,98577
+2022-02-07,0 wk ahead cum case,2022-02-05,GM09,Saarland State,observed,NA,114469
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,point,NA,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.010,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.025,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.050,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.100,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.150,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.200,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.250,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.300,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.350,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.400,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.450,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.500,54968
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.550,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.600,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.650,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.700,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.750,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.800,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.850,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.900,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.950,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.975,54969
+2022-02-07,1 wk ahead cum case,2022-02-12,GM09,Saarland State,quantile,0.990,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,point,NA,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.010,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.025,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.050,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.100,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.150,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.200,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.250,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.300,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.350,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.400,54968
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.450,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.500,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.550,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.600,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.650,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.700,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.750,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.800,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.850,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.900,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.950,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.975,54969
+2022-02-07,2 wk ahead cum case,2022-02-19,GM09,Saarland State,quantile,0.990,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,point,NA,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.010,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.025,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.050,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.100,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.150,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.200,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.250,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.300,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.350,54968
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.400,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.450,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.500,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.550,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.600,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.650,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.700,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.750,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.800,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.850,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.900,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.950,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.975,54969
+2022-02-07,3 wk ahead cum case,2022-02-26,GM09,Saarland State,quantile,0.990,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,point,NA,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.010,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.025,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.050,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.100,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.150,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.200,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.250,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.300,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.350,54968
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.400,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.450,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.500,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.550,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.600,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.650,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.700,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.750,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.800,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.850,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.900,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.950,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.975,54969
+2022-02-07,4 wk ahead cum case,2022-03-05,GM09,Saarland State,quantile,0.990,54969
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,29983
+2022-02-07,0 wk ahead inc case,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,31500
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,point,NA,31643
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,20196
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,21977
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,23506
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,25389
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,26528
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,27512
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,28207
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,28963
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,29658
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,30240
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,30959
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,31643
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,32453
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,33274
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,34018
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,34779
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,35661
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,36470
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,37633
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,39270
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,41813
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,44253
+2022-02-07,1 wk ahead inc case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,47276
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,point,NA,32405
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,15842
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,18145
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,20172
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,22834
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,24482
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,25915
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,26969
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,28044
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,29129
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,30091
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,31187
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,32405
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,33541
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,34923
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,36151
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,37421
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,38966
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,40266
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,42355
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,45293
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,49961
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,54291
+2022-02-07,2 wk ahead inc case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,60156
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,point,NA,32440
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,12407
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,14901
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,17173
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,20331
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,22340
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,24113
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,25416
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,26801
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,28256
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,29447
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,30902
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,32440
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,34061
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,35876
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,37663
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,39339
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,41417
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,43371
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,46252
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,50381
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,57183
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,63473
+2022-02-07,3 wk ahead inc case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,72132
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,point,NA,31995
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,9660
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,12200
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,14577
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,17973
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,20205
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,22210
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,23698
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,25299
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,26981
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,28437
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,30038
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,31995
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,33936
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,36103
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,38238
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,40308
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,43025
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,45354
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,48863
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,54022
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,62529
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,70324
+2022-02-07,4 wk ahead inc case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,80772
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,210917
+2022-02-07,0 wk ahead cum case,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,242417
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,point,NA,275530
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,261178
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,263521
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,265440
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,267747
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,269177
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,270334
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,271254
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,272181
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,273158
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,273826
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,274581
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,275530
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,276291
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,277463
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,278332
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,279144
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,280186
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,281214
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,282651
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,284484
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,287473
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,290190
+2022-02-07,1 wk ahead cum case,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,293798
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,point,NA,307708
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,277246
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,281837
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,285627
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,290808
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,293764
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,296198
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,298232
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,300336
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,302318
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,303970
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,305865
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,307708
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,309864
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,312298
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,314576
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,316697
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,319061
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,321443
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,324730
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,329633
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,337213
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,344498
+2022-02-07,2 wk ahead cum case,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,353817
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,point,NA,340120
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,289835
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,296882
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,303001
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,311037
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,316136
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,320402
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,323708
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,327170
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,330353
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,333320
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,336813
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,340120
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,344138
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,348217
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,352019
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,355944
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,360425
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,364721
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,370964
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,379927
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,394360
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,407928
+2022-02-07,3 wk ahead cum case,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,425668
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,point,NA,372318
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,299540
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,309004
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,317630
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,329192
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,336325
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,342666
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,347422
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,352550
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,357399
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,361828
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,367050
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,372318
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,378006
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,384393
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,390175
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,396236
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,403369
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,409989
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,420060
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,434000
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,456612
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,478338
+2022-02-07,4 wk ahead cum case,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,506359
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM11,Brandenburg State,observed,NA,34880
+2022-02-07,0 wk ahead inc case,2022-02-05,GM11,Brandenburg State,observed,NA,51629
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,point,NA,64381
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.010,43847
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.025,46494
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.050,49039
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.100,52034
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.150,54221
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.200,56071
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.250,57522
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.300,59055
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.350,60640
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.400,61805
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.450,63052
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.500,64381
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.550,65750
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.600,67304
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.650,68643
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.700,70104
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.750,71535
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.800,73436
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.850,75797
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.900,79017
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.950,83851
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.975,88236
+2022-02-07,1 wk ahead inc case,2022-02-12,GM11,Brandenburg State,quantile,0.990,94062
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,point,NA,77322
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.010,43898
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.025,47823
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.050,51747
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.100,56503
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.150,60144
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.200,63304
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.250,65665
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.300,68276
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.350,70903
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.400,73098
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.450,75060
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.500,77322
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.550,79633
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.600,82244
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.650,84622
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.700,87166
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.750,89444
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.800,92770
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.850,96644
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.900,101749
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.950,109781
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.975,117131
+2022-02-07,2 wk ahead inc case,2022-02-19,GM11,Brandenburg State,quantile,0.990,125312
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,point,NA,84344
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.010,42559
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.025,47388
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.050,52130
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.100,58218
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.150,62857
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.200,66858
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.250,69789
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.300,73170
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.350,76187
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.400,79188
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.450,81533
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.500,84344
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.550,87035
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.600,89863
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.650,92381
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.700,95537
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.750,98589
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.800,101814
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.850,105608
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.900,110609
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.950,118697
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.975,125629
+2022-02-07,3 wk ahead inc case,2022-02-26,GM11,Brandenburg State,quantile,0.990,133855
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,point,NA,82463
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.010,39950
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.025,45047
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.050,50182
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.100,56797
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.150,61774
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.200,65907
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.250,68798
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.300,72231
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.350,75149
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.400,77987
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.450,80113
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.500,82463
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.550,85130
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.600,87216
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.650,89196
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.700,91150
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.750,93236
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.800,95626
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.850,98583
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.900,102716
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.950,109172
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.975,115205
+2022-02-07,4 wk ahead inc case,2022-03-05,GM11,Brandenburg State,quantile,0.990,122150
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM11,Brandenburg State,observed,NA,327071
+2022-02-07,0 wk ahead cum case,2022-02-05,GM11,Brandenburg State,observed,NA,378700
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,point,NA,445477
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.010,419965
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.025,423711
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.050,427209
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.100,430941
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.150,433587
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.200,435638
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.250,437443
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.300,439272
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.350,440953
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.400,442338
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.450,443957
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.500,445477
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.550,447158
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.600,448728
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.650,450446
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.700,452152
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.750,453709
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.800,455749
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.850,458555
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.900,462164
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.950,467738
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.975,472720
+2022-02-07,1 wk ahead cum case,2022-02-12,GM11,Brandenburg State,quantile,0.990,479444
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,point,NA,522801
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.010,464171
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.025,471961
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.050,479203
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.100,487657
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.150,493947
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.200,498997
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.250,503209
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.300,507624
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.350,512038
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.400,515674
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.450,518992
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.500,522801
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.550,526638
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.600,531139
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.650,535035
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.700,539161
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.750,543085
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.800,548394
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.850,555232
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.900,564090
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.950,577160
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.975,589423
+2022-02-07,2 wk ahead cum case,2022-02-19,GM11,Brandenburg State,quantile,0.990,604485
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,point,NA,606900
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.010,506958
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.025,519543
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.050,531529
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.100,546096
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.150,556837
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.200,566057
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.250,572879
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.300,580624
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.350,588368
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.400,594315
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.450,600584
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.500,606900
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.550,613538
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.600,621283
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.650,627782
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.700,634559
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.750,641796
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.800,650094
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.850,661112
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.900,674803
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.950,695870
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.975,714171
+2022-02-07,3 wk ahead cum case,2022-02-26,GM11,Brandenburg State,quantile,0.990,735100
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,point,NA,690149
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.010,547396
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.025,564659
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.050,581980
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.100,602895
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.150,618625
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.200,631999
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.250,641779
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.300,653032
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.350,663755
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.400,673063
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.450,680604
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.500,690149
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.550,699399
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.600,708589
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.650,717132
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.700,726323
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.750,736692
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.800,747179
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.850,759492
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.900,776519
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.950,802560
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.975,824241
+2022-02-07,4 wk ahead cum case,2022-03-05,GM11,Brandenburg State,quantile,0.990,851047
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,16387
+2022-02-07,0 wk ahead inc case,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,23142
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,31462
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,21165
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,22892
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,24277
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,26015
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,27089
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,28012
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,28708
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,29289
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,29802
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,30378
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,30959
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,31462
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,32002
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,32495
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,33070
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,33631
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,34305
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,35234
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,36219
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,37319
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,39519
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,41308
+2022-02-07,1 wk ahead inc case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,43746
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,40132
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,21532
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,24462
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,26769
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,29809
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,31935
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,33510
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,34805
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,35838
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,37012
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,37965
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,39118
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,40132
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,40964
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,42018
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,43211
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,44516
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,45719
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,47375
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,49341
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,51709
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,56233
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,59694
+2022-02-07,2 wk ahead inc case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,64640
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,47800
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,21459
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,25336
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,28642
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,32652
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,35931
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,38214
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,39927
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,41706
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,43207
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,44893
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,46313
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,47800
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,49048
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,50588
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,52221
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,54186
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,55926
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,58156
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,60958
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,64609
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,70557
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,75721
+2022-02-07,3 wk ahead inc case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,82439
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,52238
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,20960
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,25590
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,29798
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,34427
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,38554
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,41256
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,43197
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,45315
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,47297
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,49089
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,50799
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,52238
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,54220
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,55863
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,57628
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,59718
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,61863
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,63818
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,67212
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,71352
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,77868
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,84208
+2022-02-07,4 wk ahead inc case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,91919
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,140597
+2022-02-07,0 wk ahead cum case,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,163739
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,197419
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,185314
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,187283
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,189063
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,191127
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,192387
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,193333
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,194214
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,194835
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,195538
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,196177
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,196845
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,197419
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,197992
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,198542
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,199228
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,199849
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,200606
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,201706
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,202788
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,203994
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,206555
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,208441
+2022-02-07,1 wk ahead cum case,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,211286
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,237609
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,207038
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,211911
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,215895
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,220911
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,224260
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,226879
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,229069
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,230815
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,232545
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,234228
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,235910
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,237609
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,238926
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,240577
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,242355
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,244196
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,246243
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,248989
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,252053
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,255751
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,262751
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,268195
+2022-02-07,2 wk ahead cum case,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,275798
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,285461
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,228653
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,237292
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,244516
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,253849
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,260351
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,265292
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,269048
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,272342
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,275781
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,278959
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,282224
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,285461
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,287801
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,291124
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,294592
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,298435
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,302249
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,307132
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,313056
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,320106
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,333080
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,343829
+2022-02-07,3 wk ahead cum case,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,358132
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,337792
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,249617
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,262973
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,274278
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,288304
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,299064
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,306265
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,312294
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,318198
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,322761
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,328246
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,333312
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,337792
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,341937
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,347045
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,352362
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,358684
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,364253
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,370952
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,379618
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,392137
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,409805
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,425841
+2022-02-07,4 wk ahead cum case,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,446482
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM13,Free State of Saxony,observed,NA,24031
+2022-02-07,0 wk ahead inc case,2022-02-05,GM13,Free State of Saxony,observed,NA,45104
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,point,NA,71630
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.010,49715
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.025,52617
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.050,55013
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.100,58144
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.150,60564
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.200,62394
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.250,64044
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.300,65814
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.350,67259
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.400,68631
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.450,70124
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.500,71630
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.550,73243
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.600,75025
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.650,76554
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.700,78108
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.750,80191
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.800,82310
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.850,84658
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.900,87969
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.950,93316
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.975,98289
+2022-02-07,1 wk ahead inc case,2022-02-12,GM13,Free State of Saxony,quantile,0.990,104839
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,point,NA,107621
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.010,60884
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.025,66132
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.050,71049
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.100,77734
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.150,82678
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.200,86794
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.250,90744
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.300,94501
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.350,97650
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.400,100992
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.450,104141
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.500,107621
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.550,112151
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.600,115908
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.650,119306
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.700,122924
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.750,127620
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.800,133227
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.850,138724
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.900,146762
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.950,159662
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.975,172037
+2022-02-07,2 wk ahead inc case,2022-02-19,GM13,Free State of Saxony,quantile,0.990,187644
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,point,NA,148206
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.010,72228
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.025,80357
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.050,87955
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.100,98782
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.150,107026
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.200,113826
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.250,120512
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.300,126134
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.350,131833
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.400,137379
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.450,142622
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.500,148206
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.550,155310
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.600,161768
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.650,166973
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.700,173089
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.750,180269
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.800,188665
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.850,197136
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.900,210318
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.950,228591
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.975,245686
+2022-02-07,3 wk ahead inc case,2022-02-26,GM13,Free State of Saxony,quantile,0.990,264339
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,point,NA,181394
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.010,82403
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.025,93398
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.050,103679
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.100,118112
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.150,129005
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.200,137958
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.250,147013
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.300,154366
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.350,161310
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.400,168629
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.450,174484
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.500,181394
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.550,189122
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.600,197121
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.650,202772
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.700,210738
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.750,217035
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.800,224014
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.850,233205
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.900,243451
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.950,261833
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.975,276233
+2022-02-07,4 wk ahead inc case,2022-03-05,GM13,Free State of Saxony,quantile,0.990,294513
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM13,Free State of Saxony,observed,NA,714930
+2022-02-07,0 wk ahead cum case,2022-02-05,GM13,Free State of Saxony,observed,NA,760034
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,point,NA,835137
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.010,809656
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.025,813312
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.050,816310
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.100,819898
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.150,822718
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.200,824868
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.250,826730
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.300,828647
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.350,830112
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.400,831769
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.450,833631
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.500,835137
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.550,836794
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.600,838642
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.650,840381
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.700,842188
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.750,844393
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.800,846871
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.850,849527
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.900,852936
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.950,858920
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.975,864438
+2022-02-07,1 wk ahead cum case,2022-02-12,GM13,Free State of Saxony,quantile,0.990,871736
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,point,NA,942827
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.010,871026
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.025,879713
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.050,887617
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.100,897622
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.150,905403
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.200,911702
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.250,917384
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.300,922900
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.350,927758
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.400,933028
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.450,937639
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.500,942827
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.550,948673
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.600,954437
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.650,959912
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.700,965059
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.750,972346
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.800,980127
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.850,987908
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.900,1000053
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.950,1018045
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.975,1035789
+2022-02-07,2 wk ahead cum case,2022-02-19,GM13,Free State of Saxony,quantile,0.990,1058556
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,point,NA,1090523
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.010,943632
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.025,960252
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.050,975843
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.100,996421
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.150,1012487
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.200,1025783
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.250,1037734
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.300,1049368
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.350,1059340
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.400,1069946
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.450,1080630
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.500,1090523
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.550,1104690
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.600,1116007
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.650,1126692
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.700,1137534
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.750,1152493
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.800,1169113
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.850,1185258
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.900,1209872
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.950,1247070
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.975,1281339
+2022-02-07,3 wk ahead cum case,2022-02-26,GM13,Free State of Saxony,quantile,0.990,1323443
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,point,NA,1271698
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.010,1026220
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.025,1053957
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.050,1079448
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.100,1115046
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.150,1141997
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.200,1163782
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.250,1184781
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.300,1203984
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.350,1220716
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.400,1238796
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.450,1255191
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.500,1271698
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.550,1294158
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.600,1313136
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.650,1329531
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.700,1348734
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.750,1370294
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.800,1393427
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.850,1418918
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.900,1455639
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.950,1507520
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.975,1552438
+2022-02-07,4 wk ahead cum case,2022-03-05,GM13,Free State of Saxony,quantile,0.990,1605891
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,14418
+2022-02-07,0 wk ahead inc case,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,28833
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,50537
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,43192
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,44260
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,45105
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,45920
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,46575
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,47229
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,47574
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,48229
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,48982
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,49420
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,50136
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,50537
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,50994
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,51506
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,52148
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,52790
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,53765
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,54796
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,56018
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,57827
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,60561
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,63228
+2022-02-07,1 wk ahead inc case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,66919
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,79531
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,64557
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,66133
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,67667
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,69357
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,70805
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,71922
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,72897
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,74573
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,76121
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,77095
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,78227
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,79531
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,80620
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,81823
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,83328
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,85320
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,87540
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,89933
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,92770
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,96840
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,104090
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,110724
+2022-02-07,2 wk ahead inc case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,119966
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,111232
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,88223
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,90719
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,92673
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,95712
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,97756
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,99438
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,100939
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,103526
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,105914
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,107361
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,109369
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,111232
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,113240
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,115085
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,117618
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,121181
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,123804
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,127494
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,132197
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,138257
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,147971
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,157576
+2022-02-07,3 wk ahead inc case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,167959
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,133509
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,107961
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,110801
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,112984
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,116626
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,118690
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,120755
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,122477
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,125318
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,127711
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,129183
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,131498
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,133509
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,135600
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,137664
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,140097
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,143148
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,146211
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,149512
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,153404
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,158137
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,164896
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,170116
+2022-02-07,4 wk ahead inc case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,176941
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,259743
+2022-02-07,0 wk ahead cum case,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,288576
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,342027
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,332251
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,333938
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,334974
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,336146
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,337096
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,337925
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,338583
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,339176
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,339912
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,340677
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,341441
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,342027
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,342571
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,343164
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,343793
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,344350
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,345393
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,346680
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,348102
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,349946
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,352997
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,355749
+2022-02-07,1 wk ahead cum case,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,359758
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,421451
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,396961
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,400185
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,402940
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,405651
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,408213
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,410220
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,411501
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,414021
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,416220
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,417629
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,419828
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,421451
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,423202
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,424825
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,427131
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,429565
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,432917
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,436461
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,440795
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,446966
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,456894
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,466481
+2022-02-07,2 wk ahead cum case,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,479356
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,532874
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,485624
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,491146
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,496036
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,501400
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,505857
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,509486
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,512523
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,517650
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,522383
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,525222
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,529009
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,532874
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,536305
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,539855
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,544666
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,550267
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,557051
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,564071
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,572630
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,584343
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,605168
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,623508
+2022-02-07,3 wk ahead cum case,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,647487
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,666370
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,593516
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,601824
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,608938
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,617714
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,625192
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,630125
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,634746
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,642899
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,650376
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,654115
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,660139
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,666370
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,672134
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,677534
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,684337
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,694203
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,703030
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,713883
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,726086
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,742962
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,770224
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,794734
+2022-02-07,4 wk ahead cum case,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,821788
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM15,Free State of Thuringia,observed,NA,8614
+2022-02-07,0 wk ahead inc case,2022-02-05,GM15,Free State of Thuringia,observed,NA,16529
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,point,NA,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,0
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,1
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,1
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,1
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,1
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,2
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,2
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,2
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,3
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,4
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,4
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,4
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,5
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,6
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,6
+2022-02-07,1 wk ahead inc case,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,6
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,point,NA,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,0
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,1
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,2
+2022-02-07,2 wk ahead inc case,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,2
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,point,NA,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,0
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,1
+2022-02-07,3 wk ahead inc case,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,1
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,point,NA,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,0
+2022-02-07,4 wk ahead inc case,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,0
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM15,Free State of Thuringia,observed,NA,316681
+2022-02-07,0 wk ahead cum case,2022-02-05,GM15,Free State of Thuringia,observed,NA,333210
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,point,NA,270796
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,270774
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,270775
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,270776
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,270778
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,270781
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,270783
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,270785
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,270787
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,270789
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,270792
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,270794
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,270796
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,270798
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,270801
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,270803
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,270805
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,270807
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,270809
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,270811
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,270814
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,270816
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,270817
+2022-02-07,1 wk ahead cum case,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,270818
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,point,NA,270797
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,270774
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,270775
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,270776
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,270779
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,270781
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,270783
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,270786
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,270788
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,270790
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,270793
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,270795
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,270797
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,270800
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,270802
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,270804
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,270807
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,270809
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,270811
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,270813
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,270816
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,270818
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,270819
+2022-02-07,2 wk ahead cum case,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,270820
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,point,NA,270798
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,270774
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,270775
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,270777
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,270779
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,270781
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,270784
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,270786
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,270788
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,270791
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,270793
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,270795
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,270798
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,270800
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,270802
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,270805
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,270807
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,270809
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,270812
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,270814
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,270816
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,270819
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,270820
+2022-02-07,3 wk ahead cum case,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,270821
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,point,NA,270798
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,270774
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,270775
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,270777
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,270779
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,270781
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,270784
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,270786
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,270788
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,270791
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,270793
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,270796
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,270798
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,270800
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,270803
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,270805
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,270807
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,270810
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,270812
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,270814
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,270817
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,270819
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,270820
+2022-02-07,4 wk ahead cum case,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,270821
+2022-02-07,-1 wk ahead inc case,2022-01-28,GM16,Berlin State,observed,NA,74239
+2022-02-07,0 wk ahead inc case,2022-02-05,GM16,Berlin State,observed,NA,82107
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,point,NA,68776
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.010,47575
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.025,50421
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.050,53021
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.100,56100
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.150,58273
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.200,59954
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.250,61714
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.300,63279
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.350,64585
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.400,65892
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.450,67289
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.500,68776
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.550,70484
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.600,72010
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.650,73795
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.700,75593
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.750,77611
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.800,79978
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.850,83109
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.900,86717
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.950,92836
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.975,98993
+2022-02-07,1 wk ahead inc case,2022-02-12,GM16,Berlin State,quantile,0.990,106884
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,point,NA,60824
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.010,34801
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.025,37926
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.050,40865
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.100,44455
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.150,46929
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.200,49142
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.250,51207
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.300,53216
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.350,55039
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.400,56843
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.450,58555
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.500,60824
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.550,62870
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.600,65121
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.650,67743
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.700,70310
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.750,73175
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.800,76746
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.850,81192
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.900,86530
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.950,95943
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.975,105169
+2022-02-07,2 wk ahead inc case,2022-02-19,GM16,Berlin State,quantile,0.990,117278
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,point,NA,52695
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.010,25399
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.025,28413
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.050,31281
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.100,34840
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.150,37331
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.200,39696
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.250,42019
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.300,44113
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.350,46038
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.400,48215
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.450,50099
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.500,52695
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.550,54830
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.600,57488
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.650,60544
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.700,63579
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.750,66719
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.800,71178
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.850,76097
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.900,82565
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.950,93617
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.975,104585
+2022-02-07,3 wk ahead inc case,2022-02-26,GM16,Berlin State,quantile,0.990,117940
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,point,NA,44533
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.010,18627
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.025,21155
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.050,23859
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.100,27048
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.150,29363
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.200,31833
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.250,33992
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.300,35917
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.350,37959
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.400,40099
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.450,42180
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.500,44533
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.550,46692
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.600,49629
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.650,52682
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.700,55911
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.750,59236
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.800,63457
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.850,68591
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.900,75029
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.950,86484
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.975,96928
+2022-02-07,4 wk ahead inc case,2022-03-05,GM16,Berlin State,quantile,0.990,109609
+2022-02-07,-1 wk ahead cum case,2022-01-28,GM16,Berlin State,observed,NA,511801
+2022-02-07,0 wk ahead cum case,2022-02-05,GM16,Berlin State,observed,NA,593908
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,point,NA,664036
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.010,634564
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.025,639264
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.050,642609
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.100,647025
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.150,650086
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.200,652511
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.250,654836
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.300,656626
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.350,658533
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.400,660289
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.450,662045
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.500,664036
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.550,666026
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.600,667966
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.650,670191
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.700,672449
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.750,674891
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.800,677852
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.850,681498
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.900,685863
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.950,693273
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.975,700532
+2022-02-07,1 wk ahead cum case,2022-02-12,GM16,Berlin State,quantile,0.990,709782
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,point,NA,724710
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.010,670198
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.025,677720
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.050,684018
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.100,691751
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.150,697209
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.200,701757
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.250,705956
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.300,710330
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.350,713759
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.400,717362
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.450,720721
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.500,724710
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.550,728559
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.600,733142
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.650,737551
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.700,742484
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.750,747767
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.800,754310
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.850,762777
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.900,772154
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.950,788704
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.975,805148
+2022-02-07,2 wk ahead cum case,2022-02-19,GM16,Berlin State,quantile,0.990,826456
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,point,NA,777421
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.010,696004
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.025,706236
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.050,715413
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.100,726869
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.150,734432
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.200,741495
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.250,747891
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.300,754787
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.350,759736
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.400,765353
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.450,770692
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.500,777421
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.550,783761
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.600,790546
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.650,798109
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.700,806062
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.750,814738
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.800,825026
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.850,838707
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.900,854001
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.950,881529
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.975,908780
+2022-02-07,3 wk ahead cum case,2022-02-26,GM16,Berlin State,quantile,0.990,944038
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,point,NA,822115
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.010,714644
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.025,727658
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.050,739324
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.100,754207
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.150,764229
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.200,773727
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.250,781879
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.300,790629
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.350,797883
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.400,805213
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.450,813065
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.500,822115
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.550,830790
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.600,839914
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.650,851432
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.700,861827
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.750,873569
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.800,888377
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.850,907672
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.900,928912
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.950,968101
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.975,1005570
+2022-02-07,4 wk ahead cum case,2022-03-05,GM16,Berlin State,quantile,0.990,1052761

--- a/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger.csv
+++ b/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger.csv
@@ -1,0 +1,3333 @@
+forecast_date,target,target_end_date,location,location_name,type,quantile,value
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM,Germany,observed,NA,999
+2022-02-07,0 wk ahead inc death,2022-02-05,GM,Germany,observed,NA,1192
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,point,NA,1419
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.010,1285
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.025,1309
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.050,1322
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.100,1342
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.150,1351
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.200,1364
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.250,1376
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.300,1385
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.350,1391
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.400,1400
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.450,1410
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.500,1419
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.550,1429
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.600,1437
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.650,1445
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.700,1455
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.750,1469
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.800,1486
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.850,1504
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.900,1527
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.950,1563
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.975,1600
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.990,1653
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,point,NA,1908
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.010,1624
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.025,1668
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.050,1693
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.100,1727
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.150,1753
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.200,1778
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.250,1800
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.300,1822
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.350,1845
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.400,1861
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.450,1884
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.500,1908
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.550,1933
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.600,1959
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.650,1983
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.700,2009
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.750,2044
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.800,2080
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.850,2135
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.900,2198
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.950,2295
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.975,2398
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.990,2550
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,point,NA,2379
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.010,1931
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.025,1997
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.050,2040
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.100,2085
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.150,2130
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.200,2167
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.250,2201
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.300,2236
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.350,2274
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.400,2302
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.450,2333
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.500,2379
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.550,2421
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.600,2465
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.650,2509
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.700,2553
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.750,2612
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.800,2670
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.850,2760
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.900,2864
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.950,3025
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.975,3181
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.990,3430
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,point,NA,2714
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.010,2157
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.025,2232
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.050,2287
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.100,2351
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.150,2398
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.200,2453
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.250,2490
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.300,2534
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.350,2578
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.400,2616
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.450,2659
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.500,2714
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.550,2771
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.600,2824
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.650,2879
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.700,2928
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.750,2995
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.800,3077
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.850,3171
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.900,3297
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.950,3473
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.975,3639
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.990,3867
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM,Germany,observed,NA,117484
+2022-02-07,0 wk ahead cum death,2022-02-05,GM,Germany,observed,NA,118676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,point,NA,120098
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.010,119934
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.025,119963
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.050,119984
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.100,120010
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.150,120022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.200,120033
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.250,120049
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.300,120064
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.350,120071
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.400,120079
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.450,120087
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.500,120098
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.550,120110
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.600,120119
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.650,120126
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.700,120139
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.750,120151
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.800,120165
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.850,120185
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.900,120207
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.950,120242
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.975,120276
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.990,120330
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,point,NA,122009
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.010,121560
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.025,121638
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.050,121683
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.100,121743
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.150,121777
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.200,121820
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.250,121858
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.300,121888
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.350,121916
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.400,121941
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.450,121977
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.500,122009
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.550,122040
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.600,122075
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.650,122107
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.700,122145
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.750,122191
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.800,122245
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.850,122316
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.900,122397
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.950,122526
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.975,122662
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.990,122861
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,point,NA,124390
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.010,123502
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.025,123627
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.050,123720
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.100,123831
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.150,123912
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.200,123981
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.250,124053
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.300,124124
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.350,124196
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.400,124243
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.450,124320
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.500,124390
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.550,124460
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.600,124547
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.650,124619
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.700,124691
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.750,124794
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.800,124909
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.850,125075
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.900,125257
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.950,125544
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.975,125844
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.990,126275
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,point,NA,127096
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.010,125660
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.025,125880
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.050,126008
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.100,126180
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.150,126311
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.200,126432
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.250,126541
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.300,126658
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.350,126775
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.400,126866
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.450,126969
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.500,127096
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.550,127229
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.600,127366
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.650,127496
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.700,127627
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.750,127797
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.800,127968
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.850,128246
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.900,128550
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.950,129015
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.975,129473
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.990,130145
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM01,Baden-Württemberg State,observed,NA,121
+2022-02-07,0 wk ahead inc death,2022-02-05,GM01,Baden-Württemberg State,observed,NA,140
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,point,NA,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,point,NA,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,14
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,point,NA,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,point,NA,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,2
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM01,Baden-Württemberg State,observed,NA,13619
+2022-02-07,0 wk ahead cum death,2022-02-05,GM01,Baden-Württemberg State,observed,NA,13759
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,point,NA,13764
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,13753
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,13753
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,13754
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,13755
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,13756
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,13757
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,13758
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,13759
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,13761
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,13762
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,13763
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,13764
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,13765
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,13766
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,13767
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,13769
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,13770
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,13771
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,13772
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,13773
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,13774
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,13775
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,13775
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,point,NA,13776
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,13762
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,13763
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,13763
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,13765
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,13766
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,13768
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,13769
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,13770
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,13772
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,13773
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,13774
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,13776
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,13777
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,13778
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,13780
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,13781
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,13782
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,13784
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,13785
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,13786
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,13788
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,13788
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,13789
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,point,NA,13780
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,13766
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,13766
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,13767
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,13769
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,13770
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,13771
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,13773
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,13774
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,13776
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,13777
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,13779
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,13780
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,13782
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,13783
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,13784
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,13786
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,13787
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,13789
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,13790
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,13792
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,13793
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,13794
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,13794
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,point,NA,13782
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,13767
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,13768
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,13768
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,13770
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,13771
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,13773
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,13774
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,13776
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,13777
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,13779
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,13780
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,13782
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,13783
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,13785
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,13786
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,13788
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,13789
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,13791
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,13792
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,13794
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,13795
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,13796
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,13797
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM02,Free State of Bavaria,observed,NA,144
+2022-02-07,0 wk ahead inc death,2022-02-05,GM02,Free State of Bavaria,observed,NA,217
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,point,NA,257
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,218
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,224
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,229
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,236
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,240
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,243
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,246
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,248
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,251
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,253
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,255
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,257
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,259
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,262
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,263
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,266
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,269
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,273
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,276
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,280
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,287
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,295
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,304
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,point,NA,373
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,272
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,285
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,299
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,316
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,326
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,335
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,343
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,349
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,355
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,362
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,367
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,373
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,378
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,384
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,389
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,396
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,405
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,414
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,422
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,434
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,454
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,474
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,495
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,point,NA,486
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,321
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,342
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,365
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,393
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,410
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,424
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,437
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,448
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,458
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,467
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,477
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,486
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,494
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,504
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,513
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,523
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,536
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,549
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,563
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,581
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,609
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,635
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,665
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,point,NA,556
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,356
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,384
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,413
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,448
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,469
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,485
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,501
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,516
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,525
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,535
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,546
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,556
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,566
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,574
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,586
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,597
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,608
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,620
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,633
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,649
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,677
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,701
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,734
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM02,Free State of Bavaria,observed,NA,20410
+2022-02-07,0 wk ahead cum death,2022-02-05,GM02,Free State of Bavaria,observed,NA,20627
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,point,NA,20874
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,20834
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,20841
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,20847
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,20853
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,20857
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,20861
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,20864
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,20866
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,20868
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,20870
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,20873
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,20874
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,20877
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,20878
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,20880
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,20883
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,20886
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,20889
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,20893
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,20897
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,20904
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,20911
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,20919
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,point,NA,21247
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,21109
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,21129
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,21146
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,21171
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,21184
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,21197
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,21208
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,21215
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,21223
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,21232
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,21240
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,21247
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,21255
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,21262
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,21269
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,21278
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,21290
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,21302
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,21315
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,21330
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,21356
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,21382
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,21413
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,point,NA,21734
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,21431
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,21471
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,21512
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,21565
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,21595
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,21620
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,21644
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,21664
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,21681
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,21699
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,21717
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,21734
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,21748
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,21766
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,21782
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,21803
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,21827
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,21851
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,21878
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,21910
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,21966
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,22015
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,22077
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,point,NA,22290
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,21786
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,21854
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,21925
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,22012
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,22063
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,22105
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,22145
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,22178
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,22206
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,22235
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,22265
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,22290
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,22314
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,22341
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,22368
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,22400
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,22433
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,22469
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,22513
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,22561
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,22640
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,22707
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,22796
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,19
+2022-02-07,0 wk ahead inc death,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,6
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,19
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,19
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,19
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,13
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,23
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,26
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,648
+2022-02-07,0 wk ahead cum death,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,654
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,678
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,678
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,678
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,678
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,679
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,679
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,680
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,694
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,690
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,690
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,691
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,692
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,692
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,693
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,693
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,693
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,693
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,694
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,694
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,694
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,694
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,695
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,695
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,695
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,696
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,696
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,697
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,698
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,699
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,700
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,702
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,711
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,703
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,705
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,706
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,706
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,707
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,708
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,708
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,708
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,709
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,709
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,710
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,711
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,711
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,711
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,712
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,713
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,713
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,714
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,715
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,717
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,720
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,723
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,727
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,726
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,715
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,717
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,718
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,720
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,721
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,721
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,722
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,722
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,724
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,724
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,725
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,726
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,726
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,727
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,728
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,729
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,730
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,731
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,733
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,737
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,741
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,746
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,752
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,43
+2022-02-07,0 wk ahead inc death,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,65
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,70
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,61
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,63
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,64
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,65
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,66
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,67
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,68
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,68
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,69
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,70
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,71
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,71
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,72
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,73
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,73
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,74
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,76
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,77
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,80
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,82
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,85
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,78
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,56
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,63
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,66
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,68
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,70
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,72
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,73
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,75
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,76
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,78
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,80
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,81
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,83
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,84
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,86
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,88
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,91
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,95
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,100
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,106
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,112
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,83
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,47
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,51
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,65
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,68
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,71
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,74
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,76
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,79
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,81
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,83
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,86
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,88
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,91
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,93
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,96
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,99
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,103
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,109
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,118
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,125
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,135
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,85
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,46
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,51
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,58
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,63
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,67
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,73
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,77
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,79
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,82
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,85
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,88
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,91
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,94
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,97
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,100
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,105
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,109
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,116
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,126
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,134
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,144
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,2102
+2022-02-07,0 wk ahead cum death,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,2167
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,2243
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2230
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2232
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2234
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2236
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2237
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2238
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2239
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2240
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2241
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2241
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2242
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2243
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2243
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2244
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2245
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2246
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2246
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2247
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2249
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2250
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2252
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2255
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2257
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,2321
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2283
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2289
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2293
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2299
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2303
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2306
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2309
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2312
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2314
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2316
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2319
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2321
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2323
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2325
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2328
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2330
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2332
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2335
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2339
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2345
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2352
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2360
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2369
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,2404
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2330
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2340
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2350
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2360
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2368
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2375
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2380
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2385
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2390
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2395
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2399
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2404
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2409
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2413
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2418
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2423
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2428
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2435
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2442
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2454
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2469
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2485
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2504
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,2489
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2371
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2387
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2401
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2419
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2430
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2442
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2450
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2459
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2467
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2475
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2481
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2489
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2498
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2505
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2512
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2520
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2529
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2539
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2551
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2570
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2595
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2618
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2648
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM05,Hesse State,observed,NA,74
+2022-02-07,0 wk ahead inc death,2022-02-05,GM05,Hesse State,observed,NA,90
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,point,NA,149
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.010,135
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.025,137
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.050,139
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.100,141
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.150,143
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.200,144
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.250,145
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.300,146
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.350,147
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.400,148
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.450,149
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.500,149
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.550,151
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.600,152
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.650,153
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.700,154
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.750,155
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.800,157
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.850,159
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.900,162
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.950,166
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.975,170
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.990,176
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,point,NA,203
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.010,171
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.025,175
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.050,180
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.100,184
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.150,186
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.200,189
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.250,192
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.300,195
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.350,197
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.400,199
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.450,201
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.500,203
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.550,205
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.600,208
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.650,211
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.700,214
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.750,218
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.800,222
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.850,227
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.900,236
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.950,248
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.975,259
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.990,275
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,point,NA,257
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.010,207
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.025,213
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.050,221
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.100,226
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.150,230
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.200,234
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.250,239
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.300,244
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.350,247
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.400,250
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.450,254
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.500,257
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.550,262
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.600,266
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.650,272
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.700,277
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.750,284
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.800,291
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.850,300
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.900,316
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.950,336
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.975,356
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.990,383
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,point,NA,303
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.010,237
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.025,244
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.050,254
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.100,260
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.150,266
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.200,271
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.250,278
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.300,284
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.350,288
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.400,293
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.450,299
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.500,303
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.550,308
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.600,314
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.650,322
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.700,329
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.750,338
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.800,348
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.850,358
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.900,378
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.950,402
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.975,425
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.990,455
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM05,Hesse State,observed,NA,8790
+2022-02-07,0 wk ahead cum death,2022-02-05,GM05,Hesse State,observed,NA,8880
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,point,NA,9046
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.010,9028
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.025,9031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.050,9033
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.100,9036
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.150,9038
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.200,9039
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.250,9041
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.300,9042
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.350,9043
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.400,9044
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.450,9045
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.500,9046
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.550,9047
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.600,9048
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.650,9049
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.700,9051
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.750,9052
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.800,9054
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.850,9056
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.900,9058
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.950,9062
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.975,9066
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.990,9072
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,point,NA,9249
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.010,9200
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.025,9208
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.050,9214
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.100,9221
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.150,9225
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.200,9229
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.250,9233
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.300,9237
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.350,9240
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.400,9244
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.450,9246
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.500,9249
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.550,9252
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.600,9257
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.650,9260
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.700,9264
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.750,9270
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.800,9276
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.850,9282
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.900,9294
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.950,9308
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.975,9325
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.990,9345
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,point,NA,9506
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.010,9407
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.025,9421
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.050,9435
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.100,9448
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.150,9456
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.200,9462
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.250,9472
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.300,9481
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.350,9488
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.400,9494
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.450,9500
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.500,9506
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.550,9514
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.600,9523
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.650,9532
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.700,9541
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.750,9555
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.800,9566
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.850,9583
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.900,9609
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.950,9645
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.975,9679
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.990,9728
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,point,NA,9809
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.010,9645
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.025,9663
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.050,9689
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.100,9709
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.150,9722
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.200,9734
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.250,9751
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.300,9765
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.350,9777
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.400,9786
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.450,9798
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.500,9809
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.550,9823
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.600,9837
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.650,9853
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.700,9868
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.750,9893
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.800,9913
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.850,9942
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.900,9987
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.950,10047
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.975,10106
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.990,10182
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM06,Lower Saxony State,observed,NA,35
+2022-02-07,0 wk ahead inc death,2022-02-05,GM06,Lower Saxony State,observed,NA,63
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,point,NA,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.010,43
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.025,44
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.050,46
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.100,47
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.150,48
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.200,49
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.250,49
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.300,50
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.350,50
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.400,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.450,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.500,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.550,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.600,53
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.650,53
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.700,54
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.750,54
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.800,55
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.850,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.900,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.950,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.975,60
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.990,62
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,point,NA,69
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.010,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.025,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.050,54
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.100,57
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.150,60
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.200,61
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.250,63
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.300,64
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.350,66
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.400,67
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.450,68
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.500,69
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.550,70
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.600,72
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.650,73
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.700,74
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.750,76
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.800,78
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.850,80
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.900,82
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.950,87
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.975,91
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.990,96
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,point,NA,87
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.010,50
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.025,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.050,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.100,67
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.150,71
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.200,74
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.250,76
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.300,78
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.350,81
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.400,83
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.450,85
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.500,87
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.550,89
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.600,91
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.650,93
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.700,96
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.750,98
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.800,102
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.850,105
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.900,109
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.950,117
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.975,124
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.990,132
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,point,NA,101
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.010,52
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.025,60
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.050,66
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.100,75
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.150,79
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.200,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.250,87
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.300,90
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.350,93
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.400,96
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.450,99
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.500,101
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.550,104
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.600,106
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.650,109
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.700,113
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.750,116
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.800,120
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.850,125
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.900,130
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.950,139
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.975,147
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.990,157
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM06,Lower Saxony State,observed,NA,7074
+2022-02-07,0 wk ahead cum death,2022-02-05,GM06,Lower Saxony State,observed,NA,7137
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,point,NA,7183
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.010,7174
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.025,7176
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.050,7177
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.100,7178
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.150,7179
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.200,7180
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.250,7181
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.300,7181
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.350,7182
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.400,7182
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.450,7183
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.500,7183
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.550,7184
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.600,7184
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.650,7184
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.700,7185
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.750,7185
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.800,7186
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.850,7187
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.900,7188
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.950,7189
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.975,7191
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.990,7193
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,point,NA,7252
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.010,7222
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.025,7227
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.050,7231
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.100,7236
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.150,7239
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.200,7242
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.250,7244
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.300,7245
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.350,7247
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.400,7249
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.450,7251
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.500,7252
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.550,7254
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.600,7256
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.650,7257
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.700,7259
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.750,7261
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.800,7264
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.850,7267
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.900,7270
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.950,7276
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.975,7281
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.990,7288
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,point,NA,7339
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.010,7272
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.025,7284
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.050,7292
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.100,7303
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.150,7310
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.200,7315
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.250,7320
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.300,7324
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.350,7328
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.400,7333
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.450,7336
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.500,7339
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.550,7343
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.600,7346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.650,7350
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.700,7355
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.750,7359
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.800,7365
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.850,7371
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.900,7379
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.950,7393
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.975,7405
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.990,7420
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,point,NA,7440
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.010,7324
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.025,7343
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.050,7358
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.100,7378
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.150,7389
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.200,7399
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.250,7407
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.300,7414
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.350,7422
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.400,7430
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.450,7435
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.500,7440
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.550,7447
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.600,7453
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.650,7459
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.700,7467
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.750,7476
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.800,7485
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.850,7496
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.900,7509
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.950,7532
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.975,7552
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.990,7577
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,171
+2022-02-07,0 wk ahead inc death,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,232
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,286
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,246
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,254
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,260
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,266
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,270
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,272
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,276
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,279
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,280
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,282
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,284
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,286
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,287
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,289
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,291
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,293
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,295
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,296
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,298
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,300
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,304
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,307
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,308
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,231
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,173
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,183
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,193
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,201
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,206
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,212
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,215
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,217
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,221
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,225
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,228
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,231
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,234
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,238
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,241
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,244
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,250
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,254
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,259
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,263
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,265
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,272
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,274
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,150
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,101
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,110
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,117
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,123
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,128
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,131
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,134
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,137
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,139
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,143
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,146
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,150
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,152
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,155
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,160
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,166
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,170
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,176
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,179
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,186
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,194
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,201
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,205
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,85
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,53
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,59
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,63
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,67
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,72
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,74
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,75
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,77
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,79
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,82
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,85
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,86
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,89
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,92
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,97
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,100
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,105
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,109
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,116
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,124
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,131
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,138
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,21037
+2022-02-07,0 wk ahead cum death,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,21269
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,21576
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,21535
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,21544
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,21550
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,21557
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,21560
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,21563
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,21567
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,21569
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,21571
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,21573
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,21574
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,21576
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,21578
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,21579
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,21582
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,21583
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,21585
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,21587
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,21589
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,21592
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,21598
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,21600
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,21604
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,21807
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,21712
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,21728
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,21744
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,21759
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,21768
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,21776
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,21782
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,21787
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,21793
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,21797
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,21803
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,21807
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,21813
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,21816
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,21824
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,21827
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,21832
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,21840
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,21845
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,21849
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,21858
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,21870
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,21875
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,21955
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,21814
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,21840
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,21864
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,21883
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,21896
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,21909
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,21917
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,21923
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,21932
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,21944
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,21949
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,21955
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,21965
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,21976
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,21984
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,21994
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,22003
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,22015
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,22026
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,22036
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,22048
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,22064
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,22076
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,22042
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,21867
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,21899
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,21927
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,21950
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,21966
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,21982
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,21992
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,22001
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,22010
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,22025
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,22033
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,22042
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,22052
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,22065
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,22076
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,22092
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,22104
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,22119
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,22133
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,22148
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,22179
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,22185
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,22205
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,36
+2022-02-07,0 wk ahead inc death,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,48
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,50
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,53
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,54
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,55
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,60
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,61
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,61
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,62
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,63
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,64
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,66
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,68
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,70
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,73
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,78
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,56
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,62
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,65
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,68
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,70
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,72
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,74
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,75
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,77
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,78
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,80
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,82
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,84
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,86
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,88
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,90
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,94
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,97
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,105
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,111
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,119
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,100
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,66
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,72
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,77
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,81
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,85
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,88
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,91
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,94
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,97
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,100
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,103
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,106
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,109
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,113
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,116
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,121
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,127
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,134
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,147
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,157
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,171
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,119
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,59
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,64
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,71
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,79
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,86
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,93
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,98
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,102
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,107
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,111
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,114
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,119
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,123
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,128
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,132
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,137
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,142
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,149
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,157
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,166
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,182
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,194
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,209
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,4796
+2022-02-07,0 wk ahead cum death,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,4829
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,4892
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,4881
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,4883
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,4885
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,4886
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,4887
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,4888
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,4889
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,4890
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,4890
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,4891
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,4892
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,4892
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,4893
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,4894
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,4894
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,4895
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,4896
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,4897
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,4898
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,4899
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,4901
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,4903
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,4906
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,4971
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,4935
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,4939
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,4944
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,4949
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,4953
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,4957
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,4960
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,4962
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,4964
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,4966
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,4969
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,4971
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,4973
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,4976
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,4978
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,4981
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,4984
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,4987
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,4991
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,4996
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,5005
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,5014
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,5024
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,5070
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,4992
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,5001
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,5010
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,5020
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,5030
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,5038
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,5045
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,5050
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,5055
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,5060
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,5065
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,5070
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,5076
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,5081
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,5087
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,5093
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,5100
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,5108
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,5118
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,5130
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,5153
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,5171
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,5195
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,5190
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,5050
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,5065
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,5081
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,5100
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,5116
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,5131
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,5143
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,5152
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,5162
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,5170
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,5180
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,5190
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,5200
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,5209
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,5219
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,5230
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,5242
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,5256
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,5274
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,5296
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,5335
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,5365
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,5405
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM09,Saarland State,observed,NA,12
+2022-02-07,0 wk ahead inc death,2022-02-05,GM09,Saarland State,observed,NA,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,point,NA,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.010,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.025,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.050,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.100,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.150,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.200,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.250,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.300,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.350,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.400,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.450,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.500,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.550,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.600,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.650,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.700,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.750,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.800,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.850,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.900,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.950,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.975,0
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.990,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,point,NA,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.010,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.025,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.050,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.100,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.150,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.200,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.250,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.300,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.350,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.400,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.450,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.500,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.550,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.600,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.650,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.700,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.750,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.800,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.850,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.900,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.950,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.975,0
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.990,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,point,NA,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.010,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.025,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.050,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.100,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.150,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.200,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.250,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.300,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.350,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.400,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.450,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.500,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.550,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.600,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.650,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.700,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.750,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.800,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.850,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.900,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.950,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.975,0
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.990,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,point,NA,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.010,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.025,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.050,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.100,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.150,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.200,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.250,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.300,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.350,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.400,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.450,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.500,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.550,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.600,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.650,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.700,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.750,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.800,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.850,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.900,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.950,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.975,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.990,0
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM09,Saarland State,observed,NA,1325
+2022-02-07,0 wk ahead cum death,2022-02-05,GM09,Saarland State,observed,NA,1338
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,point,NA,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.010,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.025,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.050,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.100,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.150,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.200,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.250,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.300,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.350,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.400,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.450,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.500,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.550,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.600,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.650,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.700,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.750,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.800,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.850,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.900,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.950,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.975,1277
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.990,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,point,NA,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.010,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.025,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.050,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.100,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.150,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.200,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.250,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.300,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.350,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.400,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.450,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.500,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.550,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.600,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.650,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.700,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.750,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.800,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.850,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.900,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.950,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.975,1277
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.990,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,point,NA,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.010,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.025,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.050,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.100,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.150,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.200,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.250,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.300,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.350,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.400,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.450,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.500,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.550,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.600,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.650,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.700,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.750,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.800,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.850,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.900,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.950,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.975,1277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.990,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,point,NA,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.010,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.025,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.050,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.100,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.150,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.200,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.250,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.300,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.350,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.400,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.450,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.500,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.550,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.600,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.650,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.700,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.750,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.800,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.850,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.900,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.950,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.975,1277
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.990,1277
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,25
+2022-02-07,0 wk ahead inc death,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,point,NA,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,40
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,point,NA,35
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,30
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,31
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,32
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,34
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,35
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,36
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,37
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,38
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,39
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,40
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,41
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,44
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,54
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,point,NA,36
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,25
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,27
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,30
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,31
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,32
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,33
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,34
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,36
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,37
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,39
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,40
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,43
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,45
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,47
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,50
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,55
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,60
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,67
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,point,NA,36
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,23
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,27
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,28
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,30
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,31
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,33
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,34
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,36
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,38
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,40
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,43
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,46
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,48
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,51
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,55
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,63
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,79
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,1957
+2022-02-07,0 wk ahead cum death,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,1993
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,point,NA,2027
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,2021
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,2022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,2023
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,2024
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,2026
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,2026
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,2027
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,2027
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,2027
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,2028
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,2028
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,2029
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,2029
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,2029
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,2030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,2030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,2031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,2032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,2034
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,2035
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,point,NA,2062
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,2044
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,2047
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,2049
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,2052
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,2054
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,2055
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,2057
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,2058
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,2059
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,2060
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,2061
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,2062
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,2064
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,2065
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,2066
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,2068
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,2069
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,2070
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,2072
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,2075
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,2079
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,2083
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,2089
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,point,NA,2098
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,2062
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,2067
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,2071
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,2077
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,2081
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,2084
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,2086
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,2089
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,2091
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,2093
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,2096
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,2098
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,2101
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,2104
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,2106
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,2109
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,2112
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,2115
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,2119
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,2125
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,2135
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,2144
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,2156
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,point,NA,2134
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,2076
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,2084
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,2091
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,2100
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,2106
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,2111
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,2115
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,2119
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,2122
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,2126
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,2130
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,2134
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,2138
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,2143
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,2148
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,2152
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,2157
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,2162
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,2170
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,2180
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,2197
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,2214
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,2235
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM11,Brandenburg State,observed,NA,41
+2022-02-07,0 wk ahead inc death,2022-02-05,GM11,Brandenburg State,observed,NA,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,point,NA,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.010,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.025,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.050,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.100,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.150,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.200,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.250,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.300,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.350,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.400,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.450,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.500,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.550,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.600,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.650,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.700,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.750,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.800,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.850,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.900,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.950,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.975,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.990,32
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,point,NA,32
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.010,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.025,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.050,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.100,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.150,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.200,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.250,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.300,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.350,30
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.400,31
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.450,31
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.500,32
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.550,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.600,34
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.650,34
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.700,35
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.750,36
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.800,37
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.850,38
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.900,40
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.950,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.975,45
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.990,48
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,point,NA,38
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.010,22
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.025,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.050,25
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.100,28
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.150,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.200,31
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.250,32
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.300,33
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.350,35
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.400,36
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.450,37
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.500,38
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.550,39
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.600,40
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.650,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.700,42
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.750,43
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.800,45
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.850,47
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.900,49
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.950,53
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.975,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.990,59
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,point,NA,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.010,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.025,23
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.050,26
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.100,28
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.150,31
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.200,33
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.250,34
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.300,35
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.350,37
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.400,38
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.450,39
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.500,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.550,42
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.600,43
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.650,44
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.700,45
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.750,47
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.800,48
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.850,50
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.900,52
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.950,55
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.975,58
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.990,62
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM11,Brandenburg State,observed,NA,4998
+2022-02-07,0 wk ahead cum death,2022-02-05,GM11,Brandenburg State,observed,NA,5020
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,point,NA,5045
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.010,5040
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.025,5041
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.050,5042
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.100,5043
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.150,5043
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.200,5044
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.250,5044
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.300,5044
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.350,5045
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.400,5045
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.450,5045
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.500,5045
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.550,5046
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.600,5046
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.650,5046
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.700,5047
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.750,5047
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.800,5047
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.850,5048
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.900,5048
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.950,5050
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.975,5050
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.990,5052
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,point,NA,5078
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.010,5062
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.025,5064
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.050,5066
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.100,5068
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.150,5070
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.200,5071
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.250,5072
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.300,5074
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.350,5075
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.400,5076
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.450,5077
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.500,5078
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.550,5079
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.600,5080
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.650,5081
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.700,5082
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.750,5083
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.800,5084
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.850,5086
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.900,5088
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.950,5092
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.975,5095
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.990,5099
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,point,NA,5115
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.010,5084
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.025,5088
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.050,5092
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.100,5096
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.150,5100
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.200,5102
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.250,5105
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.300,5107
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.350,5109
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.400,5111
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.450,5113
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.500,5115
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.550,5117
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.600,5120
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.650,5122
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.700,5124
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.750,5126
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.800,5129
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.850,5133
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.900,5137
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.950,5144
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.975,5151
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.990,5158
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,point,NA,5156
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.010,5105
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.025,5111
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.050,5117
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.100,5125
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.150,5130
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.200,5135
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.250,5138
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.300,5142
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.350,5146
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.400,5150
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.450,5153
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.500,5156
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.550,5159
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.600,5163
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.650,5166
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.700,5170
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.750,5173
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.800,5177
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.850,5183
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.900,5189
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.950,5199
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.975,5208
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.990,5218
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,28
+2022-02-07,0 wk ahead inc death,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,19
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,19
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,30
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,31
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,31
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,32
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,34
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,36
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,38
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,40
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,35
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,26
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,27
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,30
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,31
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,32
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,33
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,34
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,35
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,35
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,36
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,37
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,39
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,40
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,43
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,45
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,49
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,52
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,56
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,28
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,31
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,33
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,34
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,36
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,37
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,38
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,40
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,42
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,43
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,44
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,46
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,47
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,49
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,51
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,55
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,59
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,63
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,69
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,1631
+2022-02-07,0 wk ahead cum death,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,1657
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,1674
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1672
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1673
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1673
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1673
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1673
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1674
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1674
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1674
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1674
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1674
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1675
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1676
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1677
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1678
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1678
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,1702
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1688
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1691
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1692
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1695
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1696
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1697
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1698
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1699
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1700
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1701
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1701
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1702
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1703
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1703
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1704
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1705
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1706
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1707
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1708
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1710
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1713
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1715
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1718
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,1737
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1707
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1712
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1715
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1720
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1724
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1726
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1728
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1730
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1732
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1733
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1735
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1737
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1738
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1740
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1741
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1743
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1745
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1748
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1751
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1755
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1761
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1767
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1774
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,1777
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1726
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1733
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1740
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1748
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1755
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1759
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1762
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1766
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1769
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1771
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1774
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1777
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1780
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1783
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1786
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1789
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1793
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1797
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1802
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1809
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1820
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1830
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1843
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM13,Free State of Saxony,observed,NA,119
+2022-02-07,0 wk ahead inc death,2022-02-05,GM13,Free State of Saxony,observed,NA,106
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,point,NA,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.010,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.025,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.050,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.100,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.150,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.200,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.250,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.300,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.350,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.400,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.450,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.500,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.550,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.600,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.650,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.700,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.750,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.800,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.850,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.900,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.950,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.975,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.990,41
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,point,NA,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.010,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.025,35
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.050,37
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.100,40
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.150,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.200,43
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.250,44
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.300,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.350,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.400,48
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.450,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.500,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.550,52
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.600,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.650,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.700,56
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.750,58
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.800,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.850,61
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.900,64
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.950,69
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.975,73
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.990,78
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,point,NA,74
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.010,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.025,44
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.050,48
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.100,52
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.150,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.200,59
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.250,62
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.300,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.350,67
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.400,69
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.450,71
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.500,74
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.550,77
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.600,80
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.650,82
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.700,84
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.750,88
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.800,92
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.850,95
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.900,101
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.950,110
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.975,118
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.990,128
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,point,NA,98
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.010,48
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.025,53
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.050,58
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.100,66
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.150,71
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.200,75
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.250,80
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.300,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.350,87
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.400,91
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.450,94
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.500,98
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.550,102
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.600,106
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.650,110
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.700,114
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.750,118
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.800,123
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.850,128
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.900,136
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.950,146
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.975,155
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.990,166
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM13,Free State of Saxony,observed,NA,14031
+2022-02-07,0 wk ahead cum death,2022-02-05,GM13,Free State of Saxony,observed,NA,14137
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,point,NA,14146
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.010,14139
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.025,14140
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.050,14141
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.100,14142
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.150,14143
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.200,14143
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.250,14144
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.300,14144
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.350,14145
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.400,14145
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.450,14145
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.500,14146
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.550,14146
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.600,14146
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.650,14147
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.700,14147
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.750,14148
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.800,14148
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.850,14149
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.900,14150
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.950,14151
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.975,14152
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.990,14154
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,point,NA,14196
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.010,14173
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.025,14176
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.050,14179
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.100,14182
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.150,14184
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.200,14186
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.250,14188
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.300,14190
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.350,14191
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.400,14193
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.450,14195
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.500,14196
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.550,14198
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.600,14200
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.650,14201
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.700,14203
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.750,14205
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.800,14208
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.850,14210
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.900,14214
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.950,14220
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.975,14225
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.990,14232
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,point,NA,14270
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.010,14214
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.025,14220
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.050,14226
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.100,14234
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.150,14240
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.200,14245
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.250,14250
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.300,14254
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.350,14258
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.400,14262
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.450,14266
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.500,14270
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.550,14275
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.600,14279
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.650,14283
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.700,14287
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.750,14293
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.800,14299
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.850,14305
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.900,14315
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.950,14329
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.975,14343
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.990,14359
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,point,NA,14368
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.010,14262
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.025,14274
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.050,14285
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.100,14300
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.150,14312
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.200,14321
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.250,14330
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.300,14338
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.350,14345
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.400,14353
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.450,14361
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.500,14368
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.550,14378
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.600,14386
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.650,14393
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.700,14401
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.750,14411
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.800,14422
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.850,14434
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.900,14450
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.950,14476
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.975,14498
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.990,14524
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,56
+2022-02-07,0 wk ahead inc death,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,48
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,89
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,80
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,82
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,83
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,84
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,85
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,85
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,86
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,87
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,87
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,88
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,89
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,89
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,90
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,90
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,91
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,92
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,93
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,94
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,95
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,97
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,100
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,102
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,106
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,148
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,125
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,127
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,130
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,133
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,135
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,137
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,138
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,140
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,143
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,144
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,146
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,148
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,150
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,151
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,153
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,156
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,159
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,163
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,167
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,173
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,183
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,192
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,205
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,223
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,181
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,185
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,190
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,195
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,199
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,202
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,205
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,209
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,214
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,216
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,220
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,223
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,227
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,230
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,235
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,241
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,247
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,253
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,262
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,273
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,293
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,310
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,334
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,298
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,239
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,246
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,251
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,259
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,264
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,268
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,272
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,279
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,285
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,288
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,294
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,298
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,303
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,308
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,314
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,323
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,330
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,338
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,349
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,364
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,385
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,405
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,426
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,4580
+2022-02-07,0 wk ahead cum death,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,4628
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,4721
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,4710
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,4712
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,4713
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,4715
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,4716
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,4717
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,4718
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,4718
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,4719
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,4720
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,4721
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,4721
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,4722
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,4722
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,4723
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,4724
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,4725
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,4726
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,4727
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,4729
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,4731
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,4734
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,4737
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,4869
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,4834
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,4840
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,4843
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,4848
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,4851
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,4854
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,4856
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,4859
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,4862
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,4864
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,4867
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,4869
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,4871
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,4874
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,4876
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,4879
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,4883
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,4888
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,4894
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,4902
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,4914
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,4926
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,4942
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,5093
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,5016
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,5025
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,5034
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,5043
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,5050
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,5057
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,5061
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,5069
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,5076
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,5081
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,5087
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,5093
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,5098
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,5104
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,5111
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,5120
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,5130
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,5141
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,5154
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,5174
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,5207
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,5236
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,5276
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,5391
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,5256
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,5272
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,5286
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,5302
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,5315
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,5325
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,5333
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,5348
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,5361
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,5369
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,5381
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,5391
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,5402
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,5411
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,5425
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,5442
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,5459
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,5479
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,5504
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,5536
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,5591
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,5640
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,5701
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM15,Free State of Thuringia,observed,NA,54
+2022-02-07,0 wk ahead inc death,2022-02-05,GM15,Free State of Thuringia,observed,NA,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,point,NA,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,8
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,8
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,8
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,8
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,8
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,8
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,9
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,10
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,point,NA,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,point,NA,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,1
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,2
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,2
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,point,NA,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,0
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,1
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,1
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM15,Free State of Thuringia,observed,NA,6388
+2022-02-07,0 wk ahead cum death,2022-02-05,GM15,Free State of Thuringia,observed,NA,6446
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,point,NA,6437
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,6433
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,6433
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,6434
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,6434
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,6434
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,6435
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,6435
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,6435
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,6436
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,6436
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,6436
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,6437
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,6437
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,6437
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,6438
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,6438
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,6439
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,6439
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,6439
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,6440
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,6440
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,6440
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,6440
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,point,NA,6440
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,6436
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,6436
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,6437
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,6437
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,6437
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,6438
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,6438
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,6439
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,6439
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,6440
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,6440
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,6440
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,6441
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,6441
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,6442
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,6442
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,6442
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,6443
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,6443
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,6444
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,6444
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,6444
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,6444
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,point,NA,6442
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,6437
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,6438
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,6438
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,6438
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,6439
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,6439
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,6440
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,6440
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,6440
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,6441
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,6441
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,6442
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,6442
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,6443
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,6443
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,6444
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,6444
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,6444
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,6445
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,6445
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,6446
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,6446
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,6446
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,point,NA,6442
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,6438
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,6438
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,6438
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,6439
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,6439
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,6440
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,6440
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,6440
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,6441
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,6441
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,6442
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,6442
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,6443
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,6443
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,6444
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,6444
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,6445
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,6445
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,6446
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,6446
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,6446
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,6447
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,6447
+2022-02-07,-1 wk ahead inc death,2022-01-28,GM16,Berlin State,observed,NA,21
+2022-02-07,0 wk ahead inc death,2022-02-05,GM16,Berlin State,observed,NA,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,point,NA,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.010,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.025,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.050,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.100,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.150,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.200,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.250,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.300,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.350,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.400,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.450,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.500,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.550,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.600,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.650,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.700,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.750,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.800,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.850,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.900,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.950,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.975,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.990,35
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,point,NA,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.010,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.025,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.050,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.100,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.150,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.200,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.250,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.300,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.350,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.400,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.450,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.500,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.550,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.600,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.650,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.700,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.750,30
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.800,30
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.850,32
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.900,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.950,36
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.975,38
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.990,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,point,NA,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.010,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.025,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.050,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.100,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.150,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.200,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.250,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.300,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.350,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.400,22
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.450,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.500,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.550,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.600,25
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.650,26
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.700,27
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.750,28
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.800,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.850,31
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.900,33
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.950,37
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.975,40
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.990,45
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,point,NA,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.010,10
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.025,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.050,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.100,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.150,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.200,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.250,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.300,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.350,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.400,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.450,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.500,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.550,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.600,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.650,23
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.700,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.750,26
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.800,27
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.850,29
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.900,32
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.950,36
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.975,40
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.990,45
+2022-02-07,-1 wk ahead cum death,2022-01-28,GM16,Berlin State,observed,NA,4098
+2022-02-07,0 wk ahead cum death,2022-02-05,GM16,Berlin State,observed,NA,4135
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,point,NA,4163
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.010,4158
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.025,4159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.050,4159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.100,4160
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.150,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.200,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.250,4162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.300,4162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.350,4162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.400,4163
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.450,4163
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.500,4163
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.550,4164
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.600,4164
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.650,4164
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.700,4164
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.750,4165
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.800,4165
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.850,4166
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.900,4167
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.950,4168
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.975,4169
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.990,4170
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,point,NA,4189
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.010,4177
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.025,4179
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.050,4180
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.100,4182
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.150,4183
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.200,4184
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.250,4185
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.300,4186
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.350,4187
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.400,4188
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.450,4189
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.500,4189
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.550,4190
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.600,4191
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.650,4192
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.700,4193
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.750,4194
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.800,4196
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.850,4198
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.900,4200
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.950,4203
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.975,4207
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.990,4211
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,point,NA,4213
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.010,4191
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.025,4194
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.050,4196
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.100,4199
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.150,4202
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.200,4203
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.250,4205
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.300,4207
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.350,4208
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.400,4210
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.450,4211
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.500,4213
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.550,4215
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.600,4216
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.650,4218
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.700,4220
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.750,4222
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.800,4225
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.850,4229
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.900,4233
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.950,4240
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.975,4246
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.990,4255
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,point,NA,4233
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.010,4201
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.025,4205
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.050,4209
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.100,4214
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.150,4216
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.200,4219
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.250,4222
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.300,4224
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.350,4226
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.400,4229
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.450,4231
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.500,4233
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.550,4236
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.600,4239
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.650,4242
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.700,4245
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.750,4248
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.800,4252
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.850,4258
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.900,4264
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.950,4275
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.975,4286
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.990,4300

--- a/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger.csv
+++ b/data-processed/FIAS_FZJ-Epi1Ger/2022-02-07-Germany-FIAS_FZJ-Epi1Ger.csv
@@ -1,3333 +1,3333 @@
 forecast_date,target,target_end_date,location,location_name,type,quantile,value
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM,Germany,observed,NA,999
-2022-02-07,0 wk ahead inc death,2022-02-05,GM,Germany,observed,NA,1192
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,point,NA,1419
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.010,1285
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.025,1309
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.050,1322
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.100,1342
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.150,1351
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.200,1364
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.250,1376
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.300,1385
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.350,1391
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.400,1400
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.450,1410
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.500,1419
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.550,1429
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.600,1437
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.650,1445
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.700,1455
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.750,1469
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.800,1486
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.850,1504
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.900,1527
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.950,1563
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.975,1600
-2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.990,1653
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,point,NA,1908
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.010,1624
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.025,1668
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.050,1693
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.100,1727
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.150,1753
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.200,1778
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.250,1800
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.300,1822
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.350,1845
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.400,1861
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.450,1884
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.500,1908
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.550,1933
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.600,1959
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.650,1983
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.700,2009
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.750,2044
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.800,2080
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.850,2135
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.900,2198
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.950,2295
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.975,2398
-2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.990,2550
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,point,NA,2379
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.010,1931
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.025,1997
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.050,2040
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.100,2085
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.150,2130
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.200,2167
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.250,2201
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.300,2236
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.350,2274
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.400,2302
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.450,2333
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.500,2379
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.550,2421
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.600,2465
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.650,2509
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.700,2553
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.750,2612
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.800,2670
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.850,2760
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.900,2864
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.950,3025
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.975,3181
-2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.990,3430
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,point,NA,2714
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.010,2157
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.025,2232
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.050,2287
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.100,2351
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.150,2398
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.200,2453
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.250,2490
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.300,2534
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.350,2578
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.400,2616
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.450,2659
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.500,2714
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.550,2771
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.600,2824
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.650,2879
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.700,2928
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.750,2995
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.800,3077
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.850,3171
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.900,3297
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.950,3473
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.975,3639
-2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.990,3867
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM,Germany,observed,NA,117484
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM,Germany,observed,NA,1002
+2022-02-07,0 wk ahead inc death,2022-02-05,GM,Germany,observed,NA,1010
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,point,NA,1288
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.010,1214
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.025,1224
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.050,1235
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.100,1242
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.150,1248
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.200,1256
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.250,1262
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.300,1267
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.350,1270
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.400,1278
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.450,1284
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.500,1288
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.550,1294
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.600,1299
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.650,1304
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.700,1310
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.750,1319
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.800,1325
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.850,1336
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.900,1353
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.950,1378
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.975,1400
+2022-02-07,1 wk ahead inc death,2022-02-12,GM,Germany,quantile,0.990,1432
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,point,NA,1583
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.010,1443
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.025,1457
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.050,1476
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.100,1489
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.150,1503
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.200,1515
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.250,1525
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.300,1537
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.350,1549
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.400,1561
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.450,1575
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.500,1583
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.550,1596
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.600,1604
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.650,1615
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.700,1632
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.750,1650
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.800,1667
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.850,1686
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.900,1728
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.950,1797
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.975,1851
+2022-02-07,2 wk ahead inc death,2022-02-19,GM,Germany,quantile,0.990,1935
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,point,NA,1848
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.010,1639
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.025,1661
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.050,1682
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.100,1703
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.150,1728
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.200,1743
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.250,1761
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.300,1775
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.350,1789
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.400,1804
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.450,1829
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.500,1848
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.550,1866
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.600,1875
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.650,1899
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.700,1922
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.750,1952
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.800,1980
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.850,2018
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.900,2082
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.950,2202
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.975,2292
+2022-02-07,3 wk ahead inc death,2022-02-26,GM,Germany,quantile,0.990,2433
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,point,NA,2042
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.010,1772
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.025,1808
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.050,1827
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.100,1854
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.150,1881
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.200,1902
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.250,1929
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.300,1942
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.350,1967
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.400,1984
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.450,2018
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.500,2042
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.550,2058
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.600,2075
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.650,2107
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.700,2139
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.750,2172
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.800,2213
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.850,2255
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.900,2349
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.950,2506
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.975,2612
+2022-02-07,4 wk ahead inc death,2022-03-05,GM,Germany,quantile,0.990,2792
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM,Germany,observed,NA,117666
 2022-02-07,0 wk ahead cum death,2022-02-05,GM,Germany,observed,NA,118676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,point,NA,120098
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.010,119934
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.025,119963
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.050,119984
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.100,120010
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.150,120022
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.200,120033
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.250,120049
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.300,120064
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.350,120071
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.400,120079
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.450,120087
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.500,120098
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.550,120110
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.600,120119
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.650,120126
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.700,120139
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.750,120151
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.800,120165
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.850,120185
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.900,120207
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.950,120242
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.975,120276
-2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.990,120330
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,point,NA,122009
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.010,121560
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.025,121638
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.050,121683
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.100,121743
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.150,121777
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.200,121820
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.250,121858
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.300,121888
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.350,121916
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.400,121941
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.450,121977
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.500,122009
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.550,122040
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.600,122075
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.650,122107
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.700,122145
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.750,122191
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.800,122245
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.850,122316
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.900,122397
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.950,122526
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.975,122662
-2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.990,122861
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,point,NA,124390
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.010,123502
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.025,123627
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.050,123720
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.100,123831
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.150,123912
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.200,123981
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.250,124053
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.300,124124
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.350,124196
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.400,124243
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.450,124320
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.500,124390
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.550,124460
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.600,124547
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.650,124619
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.700,124691
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.750,124794
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.800,124909
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.850,125075
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.900,125257
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.950,125544
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.975,125844
-2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.990,126275
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,point,NA,127096
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.010,125660
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.025,125880
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.050,126008
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.100,126180
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.150,126311
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.200,126432
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.250,126541
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.300,126658
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.350,126775
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.400,126866
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.450,126969
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.500,127096
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.550,127229
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.600,127366
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.650,127496
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.700,127627
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.750,127797
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.800,127968
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.850,128246
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.900,128550
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.950,129015
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.975,129473
-2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.990,130145
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM01,Baden-Württemberg State,observed,NA,121
-2022-02-07,0 wk ahead inc death,2022-02-05,GM01,Baden-Württemberg State,observed,NA,140
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,point,NA,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,33
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,point,NA,12
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,11
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,11
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,11
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,11
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,11
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,12
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,12
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,12
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,12
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,12
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,13
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,13
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,13
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,13
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,13
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,14
-2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,14
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,point,NA,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,5
-2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,5
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,point,NA,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,2
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM01,Baden-Württemberg State,observed,NA,13619
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,point,NA,120022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.010,119919
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.025,119937
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.050,119949
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.100,119964
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.150,119974
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.200,119982
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.250,119988
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.300,119998
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.350,120003
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.400,120006
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.450,120012
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.500,120022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.550,120028
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.600,120036
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.650,120043
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.700,120052
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.750,120057
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.800,120066
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.850,120078
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.900,120098
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.950,120118
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.975,120143
+2022-02-07,1 wk ahead cum death,2022-02-12,GM,Germany,quantile,0.990,120173
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,point,NA,121606
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.010,121368
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.025,121398
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.050,121432
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.100,121457
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.150,121476
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.200,121503
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.250,121517
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.300,121538
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.350,121544
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.400,121571
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.450,121589
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.500,121606
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.550,121624
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.600,121640
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.650,121657
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.700,121676
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.750,121707
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.800,121730
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.850,121765
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.900,121823
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.950,121913
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.975,121987
+2022-02-07,2 wk ahead cum death,2022-02-19,GM,Germany,quantile,0.990,122098
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,point,NA,123462
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.010,123013
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.025,123055
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.050,123122
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.100,123164
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.150,123209
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.200,123245
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.250,123274
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.300,123311
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.350,123349
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.400,123387
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.450,123419
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.500,123462
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.550,123489
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.600,123518
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.650,123550
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.700,123604
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.750,123656
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.800,123711
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.850,123778
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.900,123903
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.950,124104
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.975,124268
+2022-02-07,3 wk ahead cum death,2022-02-26,GM,Germany,quantile,0.990,124528
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,point,NA,125492
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.010,124792
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.025,124859
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.050,124949
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.100,125011
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.150,125099
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.200,125142
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.250,125195
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.300,125253
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.350,125317
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.400,125363
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.450,125451
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.500,125492
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.550,125554
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.600,125589
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.650,125654
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.700,125746
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.750,125827
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.800,125925
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.850,126039
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.900,126243
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.950,126609
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.975,126881
+2022-02-07,4 wk ahead cum death,2022-03-05,GM,Germany,quantile,0.990,127321
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM01,Baden-Württemberg State,observed,NA,124
+2022-02-07,0 wk ahead inc death,2022-02-05,GM01,Baden-Württemberg State,observed,NA,118
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,point,NA,144
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,124
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,128
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,131
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,134
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,136
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,138
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,139
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,140
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,141
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,142
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,143
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,144
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,145
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,146
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,147
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,148
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,149
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,151
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,153
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,155
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,159
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,162
+2022-02-07,1 wk ahead inc death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,165
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,point,NA,193
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,147
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,156
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,162
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,170
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,175
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,178
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,182
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,184
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,187
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,189
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,191
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,193
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,196
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,199
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,202
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,204
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,207
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,210
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,215
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,220
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,229
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,237
+2022-02-07,2 wk ahead inc death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,245
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,point,NA,237
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,166
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,179
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,189
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,201
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,209
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,213
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,218
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,222
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,226
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,230
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,233
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,237
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,240
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,243
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,247
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,252
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,256
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,262
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,268
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,274
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,286
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,295
+2022-02-07,3 wk ahead inc death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,308
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,point,NA,257
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,176
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,192
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,204
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,217
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,227
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,233
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,237
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,241
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,246
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,251
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,254
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,257
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,260
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,263
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,266
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,272
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,275
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,282
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,287
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,295
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,306
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,317
+2022-02-07,4 wk ahead inc death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,332
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM01,Baden-Württemberg State,observed,NA,13641
 2022-02-07,0 wk ahead cum death,2022-02-05,GM01,Baden-Württemberg State,observed,NA,13759
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,point,NA,13764
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,13753
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,13753
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,13754
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,13755
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,13756
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,13757
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,13758
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,13759
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,13761
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,13762
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,13763
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,13764
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,13765
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,13766
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,13767
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,13769
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,13770
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,13771
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,13772
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,13773
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,13774
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,13775
-2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,13775
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,point,NA,13776
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,13762
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,13763
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,13763
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,13765
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,13766
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,13768
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,13769
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,13770
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,13772
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,13773
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,13774
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,13776
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,13777
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,13778
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,13780
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,13781
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,13782
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,13784
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,13785
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,13786
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,13788
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,13788
-2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,13789
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,point,NA,13780
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,13766
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,13766
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,13767
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,13769
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,13770
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,13771
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,13773
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,13774
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,13776
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,13777
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,13779
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,13780
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,13782
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,13783
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,13784
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,13786
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,13787
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,13789
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,13790
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,13792
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,13793
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,13794
-2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,13794
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,point,NA,13782
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,13767
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,13768
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,13768
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,13770
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,13771
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,13773
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,13774
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,13776
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,13777
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,13779
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,13780
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,13782
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,13783
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,13785
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,13786
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,13788
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,13789
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,13791
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,13792
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,13794
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,13795
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,13796
-2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,13797
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM02,Free State of Bavaria,observed,NA,144
-2022-02-07,0 wk ahead inc death,2022-02-05,GM02,Free State of Bavaria,observed,NA,217
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,point,NA,257
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,218
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,point,NA,13907
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.010,13887
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.025,13891
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.050,13894
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.100,13897
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.150,13899
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.200,13900
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.250,13902
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.300,13903
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.350,13904
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.400,13904
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.450,13906
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.500,13907
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.550,13907
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.600,13909
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.650,13909
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.700,13911
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.750,13912
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.800,13913
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.850,13915
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.900,13917
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.950,13921
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.975,13924
+2022-02-07,1 wk ahead cum death,2022-02-12,GM01,Baden-Württemberg State,quantile,0.990,13927
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,point,NA,14100
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.010,14035
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.025,14047
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.050,14056
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.100,14067
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.150,14074
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.200,14079
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.250,14084
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.300,14087
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.350,14090
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.400,14094
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.450,14096
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.500,14100
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.550,14103
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.600,14107
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.650,14111
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.700,14115
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.750,14119
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.800,14124
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.850,14130
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.900,14137
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.950,14149
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.975,14160
+2022-02-07,2 wk ahead cum death,2022-02-19,GM01,Baden-Württemberg State,quantile,0.990,14171
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,point,NA,14336
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.010,14202
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.025,14227
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.050,14245
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.100,14267
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.150,14283
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.200,14292
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.250,14302
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.300,14309
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.350,14316
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.400,14324
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.450,14330
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.500,14336
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.550,14343
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.600,14350
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.650,14359
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.700,14366
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.750,14376
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.800,14386
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.850,14397
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.900,14411
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.950,14434
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.975,14454
+2022-02-07,3 wk ahead cum death,2022-02-26,GM01,Baden-Württemberg State,quantile,0.990,14478
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,point,NA,14596
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.010,14378
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.025,14419
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.050,14449
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.100,14486
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.150,14510
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.200,14525
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.250,14541
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.300,14551
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.350,14562
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.400,14577
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.450,14585
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.500,14596
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.550,14602
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.600,14613
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.650,14626
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.700,14637
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.750,14653
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.800,14668
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.850,14684
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.900,14703
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.950,14736
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.975,14765
+2022-02-07,4 wk ahead cum death,2022-03-05,GM01,Baden-Württemberg State,quantile,0.990,14805
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM02,Free State of Bavaria,observed,NA,131
+2022-02-07,0 wk ahead inc death,2022-02-05,GM02,Free State of Bavaria,observed,NA,198
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,point,NA,235
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,221
 2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,224
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,229
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,236
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,240
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,243
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,246
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,248
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,251
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,253
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,255
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,257
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,259
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,262
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,263
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,266
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,269
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,273
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,276
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,280
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,287
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,295
-2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,304
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,point,NA,373
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,272
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,285
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,299
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,316
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,326
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,335
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,343
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,349
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,355
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,362
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,367
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,373
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,378
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,384
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,389
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,396
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,405
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,414
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,422
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,434
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,454
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,474
-2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,495
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,point,NA,486
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,321
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,225
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,227
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,229
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,231
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,231
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,231
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,232
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,233
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,235
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,235
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,236
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,237
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,238
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,239
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,239
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,241
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,242
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,245
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,249
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,252
+2022-02-07,1 wk ahead inc death,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,258
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,point,NA,308
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,279
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,286
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,287
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,291
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,295
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,297
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,299
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,301
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,302
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,305
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,307
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,308
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,309
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,312
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,313
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,315
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,318
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,322
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,326
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,332
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,343
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,352
+2022-02-07,2 wk ahead inc death,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,367
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,point,NA,377
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,333
 2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,342
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,365
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,393
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,410
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,424
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,437
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,448
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,458
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,467
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,477
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,486
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,494
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,504
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,513
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,523
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,536
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,549
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,563
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,581
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,609
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,635
-2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,665
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,point,NA,556
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,356
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,384
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,413
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,448
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,469
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,485
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,501
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,516
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,525
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,535
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,546
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,556
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,566
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,574
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,586
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,597
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,608
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,620
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,633
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,649
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,677
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,701
-2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,734
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM02,Free State of Bavaria,observed,NA,20410
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,345
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,351
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,358
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,359
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,363
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,366
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,368
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,371
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,375
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,377
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,380
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,383
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,385
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,389
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,395
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,400
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,407
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,417
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,435
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,451
+2022-02-07,3 wk ahead inc death,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,475
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,point,NA,427
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,372
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,383
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,387
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,395
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,402
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,405
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,409
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,413
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,417
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,420
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,425
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,427
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,431
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,435
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,438
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,442
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,450
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,456
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,466
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,478
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,501
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,521
+2022-02-07,4 wk ahead inc death,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,548
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM02,Free State of Bavaria,observed,NA,20429
 2022-02-07,0 wk ahead cum death,2022-02-05,GM02,Free State of Bavaria,observed,NA,20627
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,point,NA,20874
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,20834
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,20841
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,20847
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,20853
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,20857
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,20861
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,20864
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,20866
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,20868
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,20870
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,20873
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,20874
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,20877
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,20878
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,20880
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,20883
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,20886
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,20889
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,20893
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,20897
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,20904
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,20911
-2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,20919
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,point,NA,21247
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,21109
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,21129
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,21146
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,21171
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,21184
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,21197
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,21208
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,21215
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,21223
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,21232
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,21240
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,21247
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,21255
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,21262
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,21269
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,21278
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,21290
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,21302
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,21315
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,21330
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,21356
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,21382
-2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,21413
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,point,NA,21734
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,21431
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,21471
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,21512
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,21565
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,21595
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,21620
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,21644
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,21664
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,21681
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,21699
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,21717
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,21734
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,21748
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,21766
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,21782
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,21803
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,21827
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,21851
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,21878
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,21910
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,21966
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,22015
-2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,22077
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,point,NA,22290
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,21786
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,21854
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,21925
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,22012
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,22063
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,22105
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,22145
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,22178
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,22206
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,22235
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,22265
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,22290
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,22314
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,22341
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,22368
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,22400
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,22433
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,22469
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,22513
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,22561
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,22640
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,22707
-2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,22796
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,19
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,point,NA,20862
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.010,20844
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.025,20847
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.050,20850
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.100,20852
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.150,20854
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.200,20856
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.250,20857
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.300,20858
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.350,20858
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.400,20859
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.450,20860
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.500,20862
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.550,20863
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.600,20864
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.650,20865
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.700,20866
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.750,20867
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.800,20868
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.850,20869
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.900,20872
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.950,20876
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.975,20881
+2022-02-07,1 wk ahead cum death,2022-02-12,GM02,Free State of Bavaria,quantile,0.990,20886
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,point,NA,21171
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.010,21124
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.025,21132
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.050,21137
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.100,21143
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.150,21149
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.200,21154
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.250,21156
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.300,21158
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.350,21160
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.400,21164
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.450,21169
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.500,21171
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.550,21174
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.600,21176
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.650,21179
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.700,21182
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.750,21184
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.800,21190
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.850,21195
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.900,21204
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.950,21218
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.975,21231
+2022-02-07,2 wk ahead cum death,2022-02-19,GM02,Free State of Bavaria,quantile,0.990,21252
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,point,NA,21549
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.010,21457
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.025,21476
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.050,21481
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.100,21492
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.150,21508
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.200,21514
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.250,21518
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.300,21524
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.350,21527
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.400,21537
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.450,21543
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.500,21549
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.550,21552
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.600,21558
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.650,21564
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.700,21571
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.750,21578
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.800,21590
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.850,21604
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.900,21619
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.950,21652
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.975,21681
+2022-02-07,3 wk ahead cum death,2022-02-26,GM02,Free State of Bavaria,quantile,0.990,21727
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,point,NA,21974
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.010,21829
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.025,21861
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.050,21866
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.100,21887
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.150,21909
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.200,21917
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.250,21929
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.300,21937
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.350,21944
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.400,21957
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.450,21967
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.500,21974
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.550,21983
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.600,21993
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.650,22000
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.700,22013
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.750,22028
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.800,22045
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.850,22068
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.900,22098
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.950,22152
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.975,22200
+2022-02-07,4 wk ahead cum death,2022-03-05,GM02,Free State of Bavaria,quantile,0.990,22275
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM03,Free Hanseatic City of Bremen,observed,NA,16
 2022-02-07,0 wk ahead inc death,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,6
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,16
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,16
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,19
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,19
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,19
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,20
-2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,20
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,15
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,15
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,16
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,16
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,16
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,16
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,16
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,17
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,18
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,18
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,18
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,18
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,19
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,19
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,20
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,20
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,21
-2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,23
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,16
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,13
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,14
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,14
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,15
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,15
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,15
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,15
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,15
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,16
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,16
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,16
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,16
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,17
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,17
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,17
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,17
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,18
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,18
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,19
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,20
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,21
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,23
-2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,25
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,15
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,12
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,12
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,13
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,13
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,13
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,14
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,14
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,14
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,14
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,15
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,15
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,15
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,16
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,16
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,16
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,16
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,17
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,17
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,18
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,19
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,21
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,23
-2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,26
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM03,Free Hanseatic City of Bremen,observed,NA,648
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,11
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,14
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,8
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,8
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,8
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,8
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,9
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,10
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,11
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,13
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,6
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,6
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,6
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,6
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,7
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,8
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,8
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,8
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,8
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,8
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,9
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,9
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,10
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,11
+2022-02-07,3 wk ahead inc death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,11
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,6
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,7
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,7
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,8
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,8
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,9
+2022-02-07,4 wk ahead inc death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,10
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM03,Free Hanseatic City of Bremen,observed,NA,648
 2022-02-07,0 wk ahead cum death,2022-02-05,GM03,Free Hanseatic City of Bremen,observed,NA,654
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,678
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,678
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,678
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,678
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,679
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,679
-2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,680
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,694
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,690
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,690
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,691
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,692
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,692
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,693
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,693
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,693
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,693
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,694
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,694
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,694
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,694
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,695
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,695
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,695
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,696
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,696
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,697
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,698
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,699
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,700
-2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,702
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,711
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,703
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,705
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,706
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,706
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,707
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,708
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,708
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,708
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,709
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,709
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,710
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,711
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,711
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,711
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,712
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,713
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,713
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,714
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,715
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,717
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,720
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,723
-2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,727
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,726
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,715
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,717
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,718
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,720
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,721
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,721
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,722
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,722
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,724
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,724
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,725
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,726
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,726
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,727
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,728
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,729
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,730
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,731
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,733
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,737
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,741
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,746
-2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,752
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,43
-2022-02-07,0 wk ahead inc death,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,65
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,70
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,57
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,59
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,61
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,63
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,64
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,65
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,66
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,67
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,68
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,68
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,69
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,70
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,71
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,71
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,72
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,73
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,73
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,74
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,76
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,77
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,80
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,82
-2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,85
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,78
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,53
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,56
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,59
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,63
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,66
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,68
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,70
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,72
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,73
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,75
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,76
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,78
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,80
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,81
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,83
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,84
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,86
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,88
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,91
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,95
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,100
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,106
-2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,112
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,83
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,47
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,51
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,56
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,61
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,65
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,68
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,71
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,74
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,76
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,79
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,81
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,83
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,86
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,88
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,91
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,93
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,96
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,99
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,103
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,109
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,118
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,125
-2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,135
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,85
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,41
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,46
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,51
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,58
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,63
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,67
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,70
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,73
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,77
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,79
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,82
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,85
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,88
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,91
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,94
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,97
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,100
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,105
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,109
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,116
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,126
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,134
-2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,144
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM04,Free Hanseatic City of Hamburg,observed,NA,2102
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,point,NA,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.010,669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.025,669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.050,669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.100,669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.150,669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.200,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.250,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.300,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.350,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.400,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.450,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.500,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.550,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.600,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.650,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.700,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.750,670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.800,671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.850,671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.900,671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.950,671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.975,671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM03,Free Hanseatic City of Bremen,quantile,0.990,672
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,point,NA,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.010,676
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.025,677
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.050,677
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.100,678
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.150,678
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.200,678
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.250,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.300,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.350,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.400,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.450,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.500,679
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.550,680
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.600,680
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.650,680
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.700,680
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.750,681
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.800,681
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.850,681
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.900,682
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.950,682
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.975,683
+2022-02-07,2 wk ahead cum death,2022-02-19,GM03,Free Hanseatic City of Bremen,quantile,0.990,684
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,point,NA,687
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.010,682
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.025,682
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.050,683
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.100,684
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.150,684
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.200,685
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.250,685
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.300,686
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.350,686
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.400,686
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.450,686
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.500,687
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.550,687
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.600,687
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.650,688
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.700,688
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.750,689
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.800,689
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.850,690
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.900,691
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.950,692
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.975,694
+2022-02-07,3 wk ahead cum death,2022-02-26,GM03,Free Hanseatic City of Bremen,quantile,0.990,695
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,point,NA,692
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.010,685
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.025,686
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.050,687
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.100,688
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.150,689
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.200,690
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.250,690
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.300,691
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.350,691
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.400,691
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.450,692
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.500,692
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.550,693
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.600,693
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.650,694
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.700,695
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.750,695
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.800,696
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.850,697
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.900,698
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.950,701
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.975,703
+2022-02-07,4 wk ahead cum death,2022-03-05,GM03,Free Hanseatic City of Bremen,quantile,0.990,706
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM04,Free Hanseatic City of Hamburg,observed,NA,42
+2022-02-07,0 wk ahead inc death,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,53
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,54
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,55
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,55
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,59
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,60
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,61
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,62
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,63
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,64
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,66
+2022-02-07,1 wk ahead inc death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,68
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,56
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,48
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,52
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,54
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,56
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,57
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,58
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,60
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,62
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,63
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,65
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,67
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,71
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,75
+2022-02-07,2 wk ahead inc death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,80
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,54
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,40
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,42
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,43
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,45
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,46
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,47
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,49
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,49
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,51
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,52
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,53
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,54
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,55
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,57
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,58
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,60
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,66
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,69
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,76
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,81
+2022-02-07,3 wk ahead inc death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,89
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,50
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,34
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,37
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,38
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,40
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,41
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,43
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,44
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,45
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,46
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,47
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,49
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,50
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,52
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,54
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,55
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,57
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,59
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,62
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,65
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,69
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,77
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,94
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM04,Free Hanseatic City of Hamburg,observed,NA,2110
 2022-02-07,0 wk ahead cum death,2022-02-05,GM04,Free Hanseatic City of Hamburg,observed,NA,2167
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,2243
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2230
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2232
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2234
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2236
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2237
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2238
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2239
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2240
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2241
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2241
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2242
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2243
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2243
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2244
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2245
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2246
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2246
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2247
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2249
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2250
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2252
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2255
-2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2257
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,2321
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2283
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2289
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2293
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2299
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2303
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2306
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2309
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2312
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2314
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2316
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2319
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2321
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2323
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2325
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2328
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2330
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2332
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2335
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2339
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2345
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2352
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2360
-2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2369
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,2404
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2330
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2340
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2350
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2360
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2368
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2375
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2380
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2385
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2390
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2395
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2399
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2404
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2409
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2413
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2418
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2423
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2428
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2435
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2442
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2454
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2469
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2485
-2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2504
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,2489
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2371
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2387
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2401
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2419
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2430
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2442
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2450
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2459
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2467
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2475
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2481
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2489
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2498
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2505
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2512
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2520
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2529
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2539
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2551
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2570
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2595
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2618
-2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2648
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM05,Hesse State,observed,NA,74
-2022-02-07,0 wk ahead inc death,2022-02-05,GM05,Hesse State,observed,NA,90
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,point,NA,149
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.010,135
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.025,137
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.050,139
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.100,141
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.150,143
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.200,144
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.250,145
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.300,146
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.350,147
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.400,148
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.450,149
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.500,149
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.550,151
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.600,152
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.650,153
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.700,154
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.750,155
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.800,157
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.850,159
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.900,162
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.950,166
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.975,170
-2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.990,176
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,point,NA,203
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.010,171
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.025,175
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.050,180
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.100,184
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.150,186
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.200,189
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.250,192
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.300,195
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.350,197
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.400,199
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.450,201
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.500,203
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.550,205
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.600,208
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.650,211
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.700,214
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.750,218
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.800,222
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.850,227
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.900,236
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.950,248
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.975,259
-2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.990,275
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,point,NA,257
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.010,207
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.025,213
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.050,221
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.100,226
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.150,230
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.200,234
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.250,239
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.300,244
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.350,247
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.400,250
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.450,254
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.500,257
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.550,262
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.600,266
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.650,272
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.700,277
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.750,284
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.800,291
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.850,300
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.900,316
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.950,336
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.975,356
-2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.990,383
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,point,NA,303
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.010,237
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.025,244
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.050,254
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.100,260
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.150,266
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.200,271
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.250,278
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.300,284
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.350,288
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.400,293
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.450,299
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.500,303
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.550,308
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.600,314
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.650,322
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.700,329
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.750,338
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.800,348
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.850,358
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.900,378
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.950,402
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.975,425
-2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.990,455
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM05,Hesse State,observed,NA,8790
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,point,NA,2231
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2224
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2225
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2226
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2227
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2228
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2229
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2229
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2230
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2230
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2231
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2231
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2231
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2232
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2232
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2233
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2233
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2234
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2235
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2235
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2237
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2238
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2240
+2022-02-07,1 wk ahead cum death,2022-02-12,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2242
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,point,NA,2288
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2270
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2273
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2276
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2278
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2279
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2281
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2282
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2283
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2284
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2285
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2287
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2288
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2289
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2291
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2292
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2294
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2295
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2297
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2300
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2304
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2309
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2314
+2022-02-07,2 wk ahead cum death,2022-02-19,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2321
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,point,NA,2342
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2310
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2315
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2319
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2323
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2326
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2328
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2331
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2333
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2335
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2337
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2339
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2342
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2344
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2350
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2353
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2356
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2361
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2366
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2373
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2385
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2395
+2022-02-07,3 wk ahead cum death,2022-02-26,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2409
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,point,NA,2392
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.010,2345
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.025,2352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.050,2357
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.100,2363
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.150,2367
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.200,2371
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.250,2375
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.300,2378
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.350,2381
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.400,2384
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.450,2388
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.500,2392
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.550,2396
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.600,2401
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.650,2405
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.700,2410
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.750,2416
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.800,2423
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.850,2431
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.900,2442
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.950,2462
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.975,2479
+2022-02-07,4 wk ahead cum death,2022-03-05,GM04,Free Hanseatic City of Hamburg,quantile,0.990,2503
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM05,Hesse State,observed,NA,74
+2022-02-07,0 wk ahead inc death,2022-02-05,GM05,Hesse State,observed,NA,87
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,point,NA,120
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.010,107
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.025,108
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.050,110
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.100,112
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.150,113
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.200,114
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.250,115
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.300,116
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.350,117
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.400,118
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.450,119
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.500,120
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.550,120
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.600,121
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.650,122
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.700,123
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.750,124
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.800,125
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.850,126
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.900,127
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.950,130
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.975,132
+2022-02-07,1 wk ahead inc death,2022-02-12,GM05,Hesse State,quantile,0.990,135
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,point,NA,144
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.010,115
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.025,118
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.050,122
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.100,126
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.150,129
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.200,131
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.250,133
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.300,136
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.350,138
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.400,140
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.450,142
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.500,144
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.550,146
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.600,148
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.650,150
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.700,151
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.750,154
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.800,156
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.850,159
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.900,163
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.950,170
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.975,176
+2022-02-07,2 wk ahead inc death,2022-02-19,GM05,Hesse State,quantile,0.990,184
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,point,NA,167
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.010,121
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.025,125
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.050,131
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.100,137
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.150,141
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.200,146
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.250,149
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.300,153
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.350,156
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.400,160
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.450,163
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.500,167
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.550,170
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.600,173
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.650,177
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.700,179
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.750,183
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.800,187
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.850,192
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.900,200
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.950,210
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.975,221
+2022-02-07,3 wk ahead inc death,2022-02-26,GM05,Hesse State,quantile,0.990,235
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,point,NA,184
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.010,123
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.025,129
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.050,136
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.100,144
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.150,150
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.200,156
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.250,161
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.300,166
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.350,171
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.400,175
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.450,180
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.500,184
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.550,190
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.600,194
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.650,198
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.700,202
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.750,207
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.800,213
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.850,219
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.900,229
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.950,244
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.975,259
+2022-02-07,4 wk ahead inc death,2022-03-05,GM05,Hesse State,quantile,0.990,276
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM05,Hesse State,observed,NA,8793
 2022-02-07,0 wk ahead cum death,2022-02-05,GM05,Hesse State,observed,NA,8880
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,point,NA,9046
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.010,9028
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.025,9031
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.050,9033
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.100,9036
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.150,9038
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.200,9039
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.250,9041
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.300,9042
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.350,9043
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.400,9044
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.450,9045
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.500,9046
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.550,9047
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.600,9048
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.650,9049
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.700,9051
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.750,9052
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.800,9054
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.850,9056
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.900,9058
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.950,9062
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.975,9066
-2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.990,9072
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,point,NA,9249
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.010,9200
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.025,9208
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.050,9214
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.100,9221
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.150,9225
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.200,9229
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.250,9233
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.300,9237
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.350,9240
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.400,9244
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.450,9246
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.500,9249
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.550,9252
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.600,9257
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.650,9260
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.700,9264
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.750,9270
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.800,9276
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.850,9282
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.900,9294
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.950,9308
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.975,9325
-2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.990,9345
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,point,NA,9506
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.010,9407
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.025,9421
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.050,9435
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.100,9448
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.150,9456
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.200,9462
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.250,9472
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.300,9481
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.350,9488
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.400,9494
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.450,9500
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.500,9506
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.550,9514
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.600,9523
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.650,9532
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.700,9541
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.750,9555
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.800,9566
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.850,9583
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.900,9609
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.950,9645
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.975,9679
-2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.990,9728
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,point,NA,9809
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.010,9645
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.025,9663
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.050,9689
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.100,9709
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.150,9722
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.200,9734
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.250,9751
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.300,9765
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.350,9777
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.400,9786
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.450,9798
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.500,9809
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.550,9823
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.600,9837
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.650,9853
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.700,9868
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.750,9893
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.800,9913
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.850,9942
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.900,9987
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.950,10047
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.975,10106
-2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.990,10182
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM06,Lower Saxony State,observed,NA,35
-2022-02-07,0 wk ahead inc death,2022-02-05,GM06,Lower Saxony State,observed,NA,63
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,point,NA,52
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.010,43
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.025,44
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.050,46
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.100,47
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.150,48
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.200,49
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.250,49
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.300,50
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.350,50
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.400,51
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.450,51
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.500,52
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.550,52
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.600,53
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.650,53
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.700,54
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.750,54
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.800,55
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.850,56
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.900,57
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.950,58
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.975,60
-2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.990,62
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,point,NA,69
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.010,47
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.025,51
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.050,54
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.100,57
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.150,60
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.200,61
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.250,63
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.300,64
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.350,66
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.400,67
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.450,68
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.500,69
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.550,70
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.600,72
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.650,73
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.700,74
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.750,76
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.800,78
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.850,80
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.900,82
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.950,87
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.975,91
-2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.990,96
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,point,NA,87
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.010,50
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.025,56
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.050,61
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.100,67
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.150,71
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.200,74
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.250,76
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.300,78
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.350,81
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.400,83
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.450,85
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.500,87
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.550,89
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.600,91
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.650,93
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.700,96
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.750,98
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.800,102
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.850,105
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.900,109
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.950,117
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.975,124
-2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.990,132
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,point,NA,101
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.010,52
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.025,60
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.050,66
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.100,75
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.150,79
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.200,84
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.250,87
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.300,90
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.350,93
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.400,96
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.450,99
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.500,101
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.550,104
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.600,106
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.650,109
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.700,113
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.750,116
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.800,120
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.850,125
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.900,130
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.950,139
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.975,147
-2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.990,157
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM06,Lower Saxony State,observed,NA,7074
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,point,NA,9017
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.010,9003
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.025,9006
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.050,9007
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.100,9010
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.150,9011
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.200,9012
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.250,9013
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.300,9014
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.350,9014
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.400,9016
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.450,9016
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.500,9017
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.550,9018
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.600,9019
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.650,9019
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.700,9020
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.750,9021
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.800,9022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.850,9023
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.900,9025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.950,9027
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.975,9030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM05,Hesse State,quantile,0.990,9033
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,point,NA,9161
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.010,9119
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.025,9124
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.050,9130
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.100,9136
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.150,9140
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.200,9143
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.250,9146
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.300,9149
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.350,9152
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.400,9155
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.450,9158
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.500,9161
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.550,9163
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.600,9167
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.650,9169
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.700,9171
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.750,9175
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.800,9178
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.850,9182
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.900,9187
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.950,9197
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.975,9205
+2022-02-07,2 wk ahead cum death,2022-02-19,GM05,Hesse State,quantile,0.990,9216
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,point,NA,9327
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.010,9241
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.025,9249
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.050,9261
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.100,9272
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.150,9281
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.200,9290
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.250,9296
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.300,9302
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.350,9308
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.400,9314
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.450,9322
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.500,9327
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.550,9334
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.600,9340
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.650,9346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.700,9350
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.750,9358
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.800,9365
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.850,9374
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.900,9386
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.950,9406
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.975,9426
+2022-02-07,3 wk ahead cum death,2022-02-26,GM05,Hesse State,quantile,0.990,9451
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,point,NA,9511
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.010,9364
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.025,9379
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.050,9398
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.100,9416
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.150,9431
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.200,9445
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.250,9456
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.300,9469
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.350,9479
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.400,9489
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.450,9502
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.500,9511
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.550,9524
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.600,9534
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.650,9545
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.700,9552
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.750,9564
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.800,9577
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.850,9593
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.900,9616
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.950,9649
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.975,9684
+2022-02-07,4 wk ahead cum death,2022-03-05,GM05,Hesse State,quantile,0.990,9727
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM06,Lower Saxony State,observed,NA,39
+2022-02-07,0 wk ahead inc death,2022-02-05,GM06,Lower Saxony State,observed,NA,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,point,NA,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.010,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.025,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.050,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.100,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.150,40
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.200,40
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.250,40
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.300,40
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.350,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.400,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.450,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.500,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.550,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.600,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.650,42
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.700,42
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.750,42
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.800,42
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.850,43
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.900,43
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.950,44
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.975,45
+2022-02-07,1 wk ahead inc death,2022-02-12,GM06,Lower Saxony State,quantile,0.990,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,point,NA,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.010,45
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.025,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.050,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.100,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.150,48
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.200,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.250,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.300,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.350,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.400,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.450,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.500,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.550,52
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.600,52
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.650,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.700,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.750,54
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.800,54
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.850,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.900,57
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.950,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.975,61
+2022-02-07,2 wk ahead inc death,2022-02-19,GM06,Lower Saxony State,quantile,0.990,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,point,NA,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.010,52
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.025,53
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.050,54
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.100,55
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.150,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.200,57
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.250,58
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.300,58
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.350,59
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.400,60
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.450,60
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.500,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.550,62
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.600,63
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.650,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.700,65
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.750,66
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.800,67
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.850,68
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.900,71
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.950,75
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.975,79
+2022-02-07,3 wk ahead inc death,2022-02-26,GM06,Lower Saxony State,quantile,0.990,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,point,NA,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.010,57
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.025,59
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.050,61
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.100,62
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.150,64
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.200,65
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.250,66
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.300,66
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.350,67
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.400,68
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.450,69
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.500,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.550,72
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.600,73
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.650,74
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.700,76
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.750,77
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.800,78
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.850,81
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.900,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.950,91
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.975,96
+2022-02-07,4 wk ahead inc death,2022-03-05,GM06,Lower Saxony State,quantile,0.990,104
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM06,Lower Saxony State,observed,NA,7086
 2022-02-07,0 wk ahead cum death,2022-02-05,GM06,Lower Saxony State,observed,NA,7137
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,point,NA,7183
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.010,7174
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.025,7176
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.050,7177
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.100,7178
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.150,7179
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.200,7180
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.250,7181
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.300,7181
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.350,7182
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.400,7182
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.450,7183
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.500,7183
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.550,7184
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.600,7184
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.650,7184
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.700,7185
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.750,7185
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.800,7186
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.850,7187
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.900,7188
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.950,7189
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.975,7191
-2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.990,7193
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,point,NA,7252
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.010,7222
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.025,7227
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.050,7231
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.100,7236
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.150,7239
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.200,7242
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.250,7244
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.300,7245
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.350,7247
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.400,7249
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.450,7251
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.500,7252
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.550,7254
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.600,7256
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.650,7257
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.700,7259
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.750,7261
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.800,7264
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.850,7267
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.900,7270
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.950,7276
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.975,7281
-2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.990,7288
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,point,NA,7339
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.010,7272
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.025,7284
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.050,7292
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.100,7303
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.150,7310
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.200,7315
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.250,7320
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.300,7324
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.350,7328
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.400,7333
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.450,7336
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.500,7339
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.550,7343
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.600,7346
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.650,7350
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.700,7355
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.750,7359
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.800,7365
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.850,7371
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.900,7379
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.950,7393
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.975,7405
-2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.990,7420
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,point,NA,7440
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.010,7324
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.025,7343
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.050,7358
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.100,7378
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.150,7389
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.200,7399
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.250,7407
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.300,7414
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.350,7422
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.400,7430
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.450,7435
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.500,7440
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.550,7447
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.600,7453
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.650,7459
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.700,7467
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.750,7476
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.800,7485
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.850,7496
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.900,7509
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.950,7532
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.975,7552
-2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.990,7577
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,171
-2022-02-07,0 wk ahead inc death,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,232
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,286
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,246
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,254
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,260
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,266
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,270
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,272
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,276
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,279
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,280
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,282
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,284
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,286
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,287
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,289
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,291
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,293
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,295
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,296
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,298
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,300
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,304
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,307
-2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,308
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,231
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,173
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,183
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,193
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,201
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,206
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,212
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,215
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,217
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,221
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,225
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,228
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,231
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,234
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,238
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,241
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,244
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,250
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,254
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,259
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,263
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,265
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,272
-2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,274
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,150
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,101
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,110
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,117
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,123
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,128
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,131
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,134
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,137
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,139
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,143
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,146
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,150
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,152
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,155
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,160
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,166
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,170
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,176
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,179
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,186
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,194
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,201
-2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,205
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,85
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,53
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,59
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,63
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,67
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,70
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,72
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,74
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,75
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,77
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,79
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,82
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,85
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,86
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,89
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,92
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,97
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,100
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,105
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,109
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,116
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,124
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,131
-2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,138
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM07,North Rhine-Westphalia State,observed,NA,21037
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,point,NA,7173
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.010,7169
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.025,7170
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.050,7170
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.100,7171
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.150,7171
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.200,7171
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.250,7172
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.300,7172
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.350,7172
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.400,7172
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.450,7172
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.500,7173
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.550,7173
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.600,7173
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.650,7173
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.700,7174
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.750,7174
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.800,7174
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.850,7174
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.900,7175
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.950,7176
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.975,7177
+2022-02-07,1 wk ahead cum death,2022-02-12,GM06,Lower Saxony State,quantile,0.990,7177
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,point,NA,7224
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.010,7214
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.025,7216
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.050,7217
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.100,7218
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.150,7219
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.200,7220
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.250,7221
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.300,7221
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.350,7222
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.400,7223
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.450,7223
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.500,7224
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.550,7224
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.600,7225
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.650,7226
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.700,7227
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.750,7227
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.800,7228
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.850,7230
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.900,7231
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.950,7234
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.975,7237
+2022-02-07,2 wk ahead cum death,2022-02-19,GM06,Lower Saxony State,quantile,0.990,7241
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,point,NA,7285
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.010,7266
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.025,7269
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.050,7271
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.100,7273
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.150,7275
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.200,7277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.250,7279
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.300,7280
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.350,7281
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.400,7282
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.450,7283
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.500,7285
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.550,7286
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.600,7288
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.650,7290
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.700,7292
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.750,7293
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.800,7295
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.850,7298
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.900,7302
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.950,7309
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.975,7316
+2022-02-07,3 wk ahead cum death,2022-02-26,GM06,Lower Saxony State,quantile,0.990,7325
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,point,NA,7355
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.010,7323
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.025,7328
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.050,7331
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.100,7334
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.150,7339
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.200,7342
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.250,7344
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.300,7346
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.350,7348
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.400,7351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.450,7353
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.500,7355
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.550,7358
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.600,7361
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.650,7364
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.700,7368
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.750,7370
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.800,7373
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.850,7378
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.900,7387
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.950,7400
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.975,7412
+2022-02-07,4 wk ahead cum death,2022-03-05,GM06,Lower Saxony State,quantile,0.990,7429
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM07,North Rhine-Westphalia State,observed,NA,187
+2022-02-07,0 wk ahead inc death,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,191
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,334
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,312
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,316
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,318
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,324
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,326
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,327
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,329
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,330
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,331
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,332
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,333
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,334
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,336
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,338
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,339
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,341
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,342
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,344
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,347
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,351
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,357
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,363
+2022-02-07,1 wk ahead inc death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,372
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,430
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,387
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,393
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,400
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,407
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,410
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,414
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,417
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,418
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,421
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,423
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,425
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,430
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,432
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,435
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,438
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,441
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,444
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,450
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,456
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,463
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,480
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,495
+2022-02-07,2 wk ahead inc death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,515
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,508
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,448
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,455
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,467
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,476
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,479
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,485
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,488
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,491
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,494
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,498
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,501
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,508
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,510
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,516
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,520
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,524
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,529
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,537
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,547
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,558
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,583
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,608
+2022-02-07,3 wk ahead inc death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,637
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,548
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,482
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,489
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,501
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,512
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,517
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,522
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,525
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,529
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,534
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,537
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,542
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,548
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,551
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,556
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,562
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,567
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,573
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,581
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,592
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,607
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,634
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,660
+2022-02-07,4 wk ahead inc death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,690
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM07,North Rhine-Westphalia State,observed,NA,21078
 2022-02-07,0 wk ahead cum death,2022-02-05,GM07,North Rhine-Westphalia State,observed,NA,21269
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,21576
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,21535
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,21544
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,21550
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,21557
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,21560
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,21563
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,21567
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,21569
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,21571
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,21573
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,21574
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,21576
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,21578
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,21579
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,21582
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,21583
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,21585
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,21587
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,21589
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,21592
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,21598
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,21600
-2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,21604
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,21807
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,21712
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,21728
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,21744
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,21759
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,21768
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,21776
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,21782
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,21787
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,21793
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,21797
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,21803
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,21807
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,21813
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,21816
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,21824
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,21827
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,21832
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,21840
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,21845
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,21849
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,21858
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,21870
-2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,21875
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,21955
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,21814
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,21840
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,21864
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,21883
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,21896
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,21909
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,21917
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,21923
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,21932
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,21944
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,21949
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,21955
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,21965
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,21976
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,21984
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,21994
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,22003
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,22015
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,22026
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,22036
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,22048
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,22064
-2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,22076
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,22042
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,21867
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,21899
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,21927
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,21950
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,21966
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,21982
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,21992
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,22001
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,22010
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,22025
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,22033
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,22042
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,22052
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,22065
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,22076
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,22092
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,22104
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,22119
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,22133
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,22148
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,22179
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,22185
-2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,22205
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,36
-2022-02-07,0 wk ahead inc death,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,59
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,48
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,50
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,51
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,53
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,54
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,55
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,56
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,56
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,57
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,57
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,58
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,59
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,59
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,60
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,61
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,61
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,62
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,63
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,64
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,66
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,68
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,70
-2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,73
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,78
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,53
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,56
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,59
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,62
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,65
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,68
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,70
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,72
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,74
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,75
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,77
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,78
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,80
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,82
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,84
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,86
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,88
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,90
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,94
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,97
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,105
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,111
-2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,119
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,100
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,56
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,61
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,66
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,72
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,77
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,81
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,85
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,88
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,91
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,94
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,97
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,100
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,103
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,106
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,109
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,113
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,116
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,121
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,127
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,134
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,147
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,157
-2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,171
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,119
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,59
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,64
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,71
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,79
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,86
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,93
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,98
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,102
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,107
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,111
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,114
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,119
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,123
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,128
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,132
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,137
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,142
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,149
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,157
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,166
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,182
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,194
-2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,209
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM08,Rhineland-Palatinate State,observed,NA,4796
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,point,NA,21632
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.010,21601
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.025,21606
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.050,21611
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.100,21617
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.150,21621
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.200,21623
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.250,21625
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.300,21626
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.350,21628
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.400,21629
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.450,21631
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.500,21632
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.550,21634
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.600,21635
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.650,21638
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.700,21640
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.750,21642
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.800,21644
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.850,21648
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.900,21652
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.950,21658
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.975,21665
+2022-02-07,1 wk ahead cum death,2022-02-12,GM07,North Rhine-Westphalia State,quantile,0.990,21674
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,point,NA,22060
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.010,21987
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.025,22001
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.050,22008
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.100,22027
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.150,22032
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.200,22037
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.250,22042
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.300,22046
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.350,22050
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.400,22052
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.450,22056
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.500,22060
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.550,22066
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.600,22072
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.650,22076
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.700,22080
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.750,22085
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.800,22093
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.850,22103
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.900,22114
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.950,22135
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.975,22158
+2022-02-07,2 wk ahead cum death,2022-02-19,GM07,North Rhine-Westphalia State,quantile,0.990,22186
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,point,NA,22567
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.010,22437
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.025,22459
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.050,22474
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.100,22502
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.150,22510
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.200,22524
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.250,22528
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.300,22538
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.350,22541
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.400,22549
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.450,22556
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.500,22567
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.550,22578
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.600,22587
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.650,22595
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.700,22604
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.750,22614
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.800,22628
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.850,22650
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.900,22672
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.950,22719
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.975,22764
+2022-02-07,3 wk ahead cum death,2022-02-26,GM07,North Rhine-Westphalia State,quantile,0.990,22820
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,point,NA,23119
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.010,22919
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.025,22947
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.050,22979
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.100,23013
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.150,23026
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.200,23046
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.250,23055
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.300,23067
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.350,23077
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.400,23088
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.450,23099
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.500,23119
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.550,23128
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.600,23142
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.650,23159
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.700,23172
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.750,23185
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.800,23208
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.850,23243
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.900,23275
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.950,23352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.975,23426
+2022-02-07,4 wk ahead cum death,2022-03-05,GM07,North Rhine-Westphalia State,quantile,0.990,23510
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM08,Rhineland-Palatinate State,observed,NA,34
+2022-02-07,0 wk ahead inc death,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,44
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,45
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,46
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,47
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,48
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,49
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,49
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,49
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,50
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,50
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,51
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,53
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,53
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,54
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,54
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,56
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,57
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,58
+2022-02-07,1 wk ahead inc death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,60
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,45
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,48
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,54
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,56
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,57
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,58
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,59
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,60
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,61
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,62
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,63
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,64
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,66
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,67
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,70
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,74
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,78
+2022-02-07,2 wk ahead inc death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,82
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,65
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,44
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,46
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,48
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,51
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,53
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,55
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,58
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,59
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,62
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,65
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,67
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,69
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,71
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,73
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,75
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,77
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,80
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,85
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,92
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,98
+2022-02-07,3 wk ahead inc death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,107
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,42
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,44
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,47
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,51
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,54
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,57
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,60
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,62
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,64
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,66
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,68
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,73
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,76
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,78
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,81
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,88
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,92
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,98
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,108
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,118
+2022-02-07,4 wk ahead inc death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,130
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM08,Rhineland-Palatinate State,observed,NA,4801
 2022-02-07,0 wk ahead cum death,2022-02-05,GM08,Rhineland-Palatinate State,observed,NA,4829
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,4892
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,4881
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,4883
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,4885
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,4886
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,4887
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,4888
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,4889
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,4890
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,4890
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,4891
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,4892
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,4892
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,4893
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,4894
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,4894
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,4895
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,4896
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,4897
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,4898
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,4899
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,4901
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,4903
-2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,4906
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,4971
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,4935
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,4939
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,4944
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,4949
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,4953
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,4957
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,4960
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,4962
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,4964
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,4966
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,4969
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,4971
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,4973
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,4976
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,4978
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,4981
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,4984
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,4987
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,4991
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,4996
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,5005
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,5014
-2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,5024
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,5070
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,4992
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,5001
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,5010
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,5020
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,5030
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,5038
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,5045
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,5050
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,5055
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,5060
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,5065
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,5070
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,5076
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,5081
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,5087
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,5093
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,5100
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,5108
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,5118
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,5130
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,5153
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,5171
-2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,5195
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,5190
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,5050
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,5065
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,5081
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,5100
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,5116
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,5131
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,5143
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,5152
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,5162
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,5170
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,5180
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,5190
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,5200
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,5209
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,5219
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,5230
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,5242
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,5256
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,5274
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,5296
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,5335
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,5365
-2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,5405
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM09,Saarland State,observed,NA,12
-2022-02-07,0 wk ahead inc death,2022-02-05,GM09,Saarland State,observed,NA,13
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,point,NA,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.010,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.025,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.050,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.100,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.150,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.200,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.250,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.300,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.350,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.400,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.450,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.500,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.550,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.600,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.650,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.700,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.750,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.800,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.850,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.900,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.950,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.975,0
-2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.990,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,point,NA,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.010,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.025,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.050,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.100,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.150,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.200,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.250,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.300,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.350,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.400,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.450,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.500,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.550,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.600,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.650,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.700,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.750,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.800,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.850,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.900,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.950,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.975,0
-2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.990,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,point,NA,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.010,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.025,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.050,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.100,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.150,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.200,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.250,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.300,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.350,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.400,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.450,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.500,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.550,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.600,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.650,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.700,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.750,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.800,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.850,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.900,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.950,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.975,0
-2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.990,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,point,NA,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.010,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.025,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.050,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.100,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.150,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.200,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.250,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.300,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.350,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.400,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.450,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.500,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.550,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.600,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.650,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.700,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.750,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.800,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.850,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.900,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.950,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.975,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.990,0
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM09,Saarland State,observed,NA,1325
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,point,NA,4886
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.010,4879
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.025,4880
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.050,4881
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.100,4882
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.150,4883
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.200,4884
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.250,4884
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.300,4885
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.350,4885
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.400,4886
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.450,4886
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.500,4886
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.550,4887
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.600,4887
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.650,4888
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.700,4888
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.750,4888
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.800,4889
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.850,4890
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.900,4891
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.950,4892
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.975,4893
+2022-02-07,1 wk ahead cum death,2022-02-12,GM08,Rhineland-Palatinate State,quantile,0.990,4895
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,point,NA,4945
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.010,4924
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.025,4927
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.050,4929
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.100,4933
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.150,4935
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.200,4937
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.250,4938
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.300,4940
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.350,4941
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.400,4942
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.450,4944
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.500,4945
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.550,4946
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.600,4948
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.650,4949
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.700,4951
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.750,4953
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.800,4955
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.850,4957
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.900,4960
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.950,4966
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.975,4971
+2022-02-07,2 wk ahead cum death,2022-02-19,GM08,Rhineland-Palatinate State,quantile,0.990,4977
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,point,NA,5010
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.010,4968
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.025,4973
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.050,4978
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.100,4984
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.150,4988
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.200,4992
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.250,4996
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.300,4999
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.350,5002
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.400,5005
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.450,5007
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.500,5010
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.550,5013
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.600,5016
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.650,5020
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.700,5023
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.750,5027
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.800,5031
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.850,5037
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.900,5045
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.950,5057
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.975,5069
+2022-02-07,3 wk ahead cum death,2022-02-26,GM08,Rhineland-Palatinate State,quantile,0.990,5083
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,point,NA,5080
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.010,5010
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.025,5018
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.050,5025
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.100,5035
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.150,5042
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.200,5049
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.250,5056
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.300,5061
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.350,5066
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.400,5071
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.450,5076
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.500,5080
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.550,5086
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.600,5092
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.650,5098
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.700,5105
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.750,5111
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.800,5119
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.850,5129
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.900,5143
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.950,5165
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.975,5187
+2022-02-07,4 wk ahead cum death,2022-03-05,GM08,Rhineland-Palatinate State,quantile,0.990,5213
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM09,Saarland State,observed,NA,12
+2022-02-07,0 wk ahead inc death,2022-02-05,GM09,Saarland State,observed,NA,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,point,NA,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.010,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.025,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.050,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.100,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.150,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.200,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.250,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.300,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.350,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.400,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.450,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.500,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.550,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.600,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.650,3
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.700,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.750,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.800,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.850,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.900,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.950,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.975,4
+2022-02-07,1 wk ahead inc death,2022-02-12,GM09,Saarland State,quantile,0.990,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,point,NA,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.010,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.025,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.050,3
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.100,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.150,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.200,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.250,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.300,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.350,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.400,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.450,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.500,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.550,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.600,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.650,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.700,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.750,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.800,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.850,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.900,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.950,4
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.975,5
+2022-02-07,2 wk ahead inc death,2022-02-19,GM09,Saarland State,quantile,0.990,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,point,NA,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.010,3
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.025,3
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.050,3
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.100,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.150,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.200,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.250,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.300,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.350,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.400,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.450,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.500,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.550,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.600,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.650,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.700,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.750,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.800,4
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.850,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.900,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.950,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.975,5
+2022-02-07,3 wk ahead inc death,2022-02-26,GM09,Saarland State,quantile,0.990,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,point,NA,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.010,3
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.025,3
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.050,3
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.100,3
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.150,3
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.200,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.250,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.300,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.350,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.400,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.450,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.500,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.550,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.600,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.650,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.700,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.750,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.800,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.850,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.900,4
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.950,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.975,5
+2022-02-07,4 wk ahead inc death,2022-03-05,GM09,Saarland State,quantile,0.990,5
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM09,Saarland State,observed,NA,1326
 2022-02-07,0 wk ahead cum death,2022-02-05,GM09,Saarland State,observed,NA,1338
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,point,NA,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.010,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.025,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.050,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.100,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.150,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.200,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.250,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.300,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.350,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.400,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.450,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.500,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.550,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.600,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.650,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.700,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.750,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.800,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.850,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.900,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.950,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.975,1277
-2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.990,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,point,NA,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.010,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.025,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.050,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.100,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.150,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.200,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.250,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.300,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.350,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.400,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.450,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.500,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.550,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.600,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.650,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.700,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.750,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.800,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.850,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.900,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.950,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.975,1277
-2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.990,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,point,NA,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.010,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.025,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.050,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.100,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.150,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.200,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.250,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.300,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.350,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.400,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.450,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.500,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.550,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.600,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.650,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.700,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.750,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.800,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.850,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.900,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.950,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.975,1277
-2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.990,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,point,NA,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.010,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.025,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.050,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.100,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.150,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.200,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.250,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.300,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.350,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.400,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.450,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.500,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.550,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.600,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.650,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.700,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.750,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.800,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.850,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.900,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.950,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.975,1277
-2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.990,1277
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,25
-2022-02-07,0 wk ahead inc death,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,36
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,point,NA,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,35
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,35
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,35
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,36
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,36
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,37
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,38
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,39
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,40
-2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,42
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,point,NA,35
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,22
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,24
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,29
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,30
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,31
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,32
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,33
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,33
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,34
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,35
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,36
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,37
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,38
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,39
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,40
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,41
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,42
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,44
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,47
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,50
-2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,54
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,point,NA,36
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,18
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,20
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,23
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,25
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,27
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,29
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,30
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,31
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,32
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,33
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,34
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,36
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,37
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,39
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,40
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,41
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,43
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,45
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,47
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,50
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,55
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,60
-2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,67
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,point,NA,36
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,14
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,17
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,19
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,23
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,25
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,27
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,28
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,30
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,31
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,33
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,34
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,36
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,38
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,40
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,41
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,43
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,46
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,48
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,51
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,55
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,63
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,70
-2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,79
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM10,Schleswig-Holstein State,observed,NA,1957
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,point,NA,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.010,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.025,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.050,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.100,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.150,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.200,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.250,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.300,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.350,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.400,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.450,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.500,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.550,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.600,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.650,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.700,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.750,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.800,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.850,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.900,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.950,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.975,1339
+2022-02-07,1 wk ahead cum death,2022-02-12,GM09,Saarland State,quantile,0.990,1339
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,point,NA,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.010,1342
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.025,1342
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.050,1342
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.100,1342
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.150,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.200,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.250,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.300,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.350,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.400,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.450,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.500,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.550,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.600,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.650,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.700,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.750,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.800,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.850,1343
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.900,1344
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.950,1344
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.975,1344
+2022-02-07,2 wk ahead cum death,2022-02-19,GM09,Saarland State,quantile,0.990,1344
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,point,NA,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.010,1345
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.025,1346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.050,1346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.100,1346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.150,1346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.200,1346
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.250,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.300,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.350,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.400,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.450,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.500,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.550,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.600,1347
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.650,1348
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.700,1348
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.750,1348
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.800,1348
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.850,1348
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.900,1348
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.950,1349
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.975,1349
+2022-02-07,3 wk ahead cum death,2022-02-26,GM09,Saarland State,quantile,0.990,1349
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,point,NA,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.010,1348
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.025,1349
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.050,1349
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.100,1349
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.150,1350
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.200,1350
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.250,1350
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.300,1350
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.350,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.400,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.450,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.500,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.550,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.600,1351
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.650,1352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.700,1352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.750,1352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.800,1352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.850,1352
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.900,1353
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.950,1353
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.975,1354
+2022-02-07,4 wk ahead cum death,2022-03-05,GM09,Saarland State,quantile,0.990,1354
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM10,Schleswig-Holstein State,observed,NA,29
+2022-02-07,0 wk ahead inc death,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,point,NA,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,34
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,point,NA,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,26
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,28
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,30
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,31
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,33
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,34
+2022-02-07,2 wk ahead inc death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,37
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,point,NA,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,13
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,22
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,22
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,25
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,26
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,27
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,27
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,30
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,33
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,35
+2022-02-07,3 wk ahead inc death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,38
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,point,NA,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,9
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,11
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,23
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,24
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,27
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,29
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,32
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,35
+2022-02-07,4 wk ahead inc death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,39
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM10,Schleswig-Holstein State,observed,NA,1963
 2022-02-07,0 wk ahead cum death,2022-02-05,GM10,Schleswig-Holstein State,observed,NA,1993
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,point,NA,2027
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,2021
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,2022
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,2023
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,2024
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,2025
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,2025
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,2025
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,2026
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,2026
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,2027
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,2027
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,2027
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,2028
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,2028
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,2029
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,2029
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,2029
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,2030
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,2030
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,2031
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,2032
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,2034
-2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,2035
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,point,NA,2062
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,2044
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,2047
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,2049
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,2052
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,2054
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,2055
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,2057
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,2058
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,2059
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,2060
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,2061
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,2062
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,2064
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,2065
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,2066
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,2068
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,2069
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,2070
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,2072
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,2075
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,2079
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,2083
-2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,2089
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,point,NA,2098
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,2062
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,2067
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,2071
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,2077
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,2081
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,2084
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,2086
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,2089
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,2091
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,2093
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,2096
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,2098
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,2101
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,2104
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,2106
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,2109
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,2112
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,2115
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,2119
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,2125
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,2135
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,2144
-2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,2156
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,point,NA,2134
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,2076
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,2084
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,2091
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,2100
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,2106
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,2111
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,2115
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,2119
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,2122
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,2126
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,2130
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,2134
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,2138
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,2143
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,2148
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,2152
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,2157
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,2162
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,2170
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,2180
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,2197
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,2214
-2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,2235
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM11,Brandenburg State,observed,NA,41
-2022-02-07,0 wk ahead inc death,2022-02-05,GM11,Brandenburg State,observed,NA,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,point,NA,25
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.010,20
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.025,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.050,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.100,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.150,23
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.200,23
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.250,24
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.300,24
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.350,24
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.400,25
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.450,25
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.500,25
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.550,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.600,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.650,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.700,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.750,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.800,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.850,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.900,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.950,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.975,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.990,32
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,point,NA,32
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.010,21
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.025,23
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.050,24
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.100,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.150,27
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.200,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.250,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.300,29
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.350,30
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.400,31
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.450,31
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.500,32
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.550,33
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.600,34
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.650,34
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.700,35
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.750,36
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.800,37
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.850,38
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.900,40
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.950,42
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.975,45
-2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.990,48
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,point,NA,38
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.010,22
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.025,23
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.050,25
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.100,28
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.150,29
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.200,31
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.250,32
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.300,33
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.350,35
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.400,36
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.450,37
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.500,38
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.550,39
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.600,40
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.650,41
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.700,42
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.750,43
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.800,45
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.850,47
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.900,49
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.950,53
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.975,56
-2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.990,59
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,point,NA,41
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.010,21
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.025,23
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.050,26
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.100,28
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.150,31
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.200,33
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.250,34
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.300,35
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.350,37
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.400,38
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.450,39
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.500,41
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.550,42
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.600,43
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.650,44
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.700,45
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.750,47
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.800,48
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.850,50
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.900,52
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.950,55
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.975,58
-2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.990,62
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM11,Brandenburg State,observed,NA,4998
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,point,NA,2024
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.010,2020
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.025,2021
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.050,2021
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.100,2022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.150,2022
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.200,2023
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.250,2023
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.300,2023
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.350,2024
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.400,2024
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.450,2024
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.500,2024
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.550,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.600,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.650,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.700,2025
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.750,2026
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.800,2026
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.850,2026
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.900,2027
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.950,2028
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.975,2028
+2022-02-07,1 wk ahead cum death,2022-02-12,GM10,Schleswig-Holstein State,quantile,0.990,2029
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,point,NA,2050
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.010,2038
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.025,2040
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.050,2042
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.100,2044
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.150,2045
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.200,2046
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.250,2047
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.300,2048
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.350,2049
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.400,2049
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.450,2050
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.500,2050
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.550,2051
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.600,2052
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.650,2053
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.700,2053
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.750,2054
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.800,2055
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.850,2056
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.900,2058
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.950,2060
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.975,2063
+2022-02-07,2 wk ahead cum death,2022-02-19,GM10,Schleswig-Holstein State,quantile,0.990,2066
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,point,NA,2074
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.010,2052
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.025,2055
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.050,2058
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.100,2061
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.150,2064
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.200,2065
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.250,2067
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.300,2068
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.350,2070
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.400,2071
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.450,2072
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.500,2074
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.550,2075
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.600,2076
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.650,2078
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.700,2079
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.750,2081
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.800,2083
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.850,2085
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.900,2088
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.950,2093
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.975,2098
+2022-02-07,3 wk ahead cum death,2022-02-26,GM10,Schleswig-Holstein State,quantile,0.990,2104
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,point,NA,2094
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.010,2061
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.025,2066
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.050,2070
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.100,2075
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.150,2078
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.200,2081
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.250,2084
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.300,2086
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.350,2088
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.400,2090
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.450,2092
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.500,2094
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.550,2096
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.600,2098
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.650,2100
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.700,2103
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.750,2105
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.800,2108
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.850,2112
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.900,2117
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.950,2125
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.975,2133
+2022-02-07,4 wk ahead cum death,2022-03-05,GM10,Schleswig-Holstein State,quantile,0.990,2143
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM11,Brandenburg State,observed,NA,38
+2022-02-07,0 wk ahead inc death,2022-02-05,GM11,Brandenburg State,observed,NA,20
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,point,NA,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.010,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.025,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.050,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.100,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.150,12
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.200,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.250,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.300,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.350,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.400,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.450,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.500,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.550,13
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.600,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.650,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.700,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.750,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.800,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.850,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.900,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.950,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.975,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM11,Brandenburg State,quantile,0.990,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,point,NA,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.010,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.025,12
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.050,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.100,13
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.150,14
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.200,14
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.250,14
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.300,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.350,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.400,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.450,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.500,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.550,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.600,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.650,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.700,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.750,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.800,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.850,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.900,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.950,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.975,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM11,Brandenburg State,quantile,0.990,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,point,NA,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.010,12
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.025,12
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.050,13
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.100,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.150,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.200,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.250,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.300,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.350,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.400,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.450,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.500,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.550,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.600,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.650,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.700,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.750,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.800,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.850,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.900,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.950,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.975,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM11,Brandenburg State,quantile,0.990,26
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,point,NA,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.010,11
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.025,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.050,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.100,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.150,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.200,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.250,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.300,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.350,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.400,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.450,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.500,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.550,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.600,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.650,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.700,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.750,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.800,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.850,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.900,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.950,24
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.975,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM11,Brandenburg State,quantile,0.990,26
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM11,Brandenburg State,observed,NA,5000
 2022-02-07,0 wk ahead cum death,2022-02-05,GM11,Brandenburg State,observed,NA,5020
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,point,NA,5045
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.010,5040
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.025,5041
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.050,5042
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.100,5043
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.150,5043
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.200,5044
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.250,5044
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.300,5044
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.350,5045
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.400,5045
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.450,5045
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.500,5045
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.550,5046
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.600,5046
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.650,5046
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.700,5047
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.750,5047
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.800,5047
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.850,5048
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.900,5048
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.950,5050
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.975,5050
-2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.990,5052
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,point,NA,5078
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.010,5062
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.025,5064
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.050,5066
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.100,5068
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.150,5070
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.200,5071
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.250,5072
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.300,5074
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.350,5075
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.400,5076
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.450,5077
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.500,5078
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.550,5079
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.600,5080
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.650,5081
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.700,5082
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.750,5083
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.800,5084
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.850,5086
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.900,5088
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.950,5092
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.975,5095
-2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.990,5099
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,point,NA,5115
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.010,5084
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.025,5088
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.050,5092
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.100,5096
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.150,5100
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.200,5102
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.250,5105
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.300,5107
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.350,5109
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.400,5111
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.450,5113
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.500,5115
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.550,5117
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.600,5120
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.650,5122
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.700,5124
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.750,5126
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.800,5129
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.850,5133
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.900,5137
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.950,5144
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.975,5151
-2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.990,5158
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,point,NA,5156
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.010,5105
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.025,5111
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.050,5117
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.100,5125
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.150,5130
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.200,5135
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.250,5138
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.300,5142
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.350,5146
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.400,5150
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.450,5153
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.500,5156
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.550,5159
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.600,5163
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.650,5166
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.700,5170
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.750,5173
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.800,5177
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.850,5183
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.900,5189
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.950,5199
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.975,5208
-2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.990,5218
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,28
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,point,NA,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.010,5029
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.025,5030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.050,5030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.100,5030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.150,5030
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.200,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.250,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.300,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.350,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.400,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.450,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.500,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.550,5031
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.600,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.650,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.700,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.750,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.800,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.850,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.900,5032
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.950,5033
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.975,5033
+2022-02-07,1 wk ahead cum death,2022-02-12,GM11,Brandenburg State,quantile,0.990,5034
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,point,NA,5047
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.010,5041
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.025,5042
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.050,5043
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.100,5044
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.150,5044
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.200,5045
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.250,5045
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.300,5045
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.350,5046
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.400,5046
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.450,5046
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.500,5047
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.550,5047
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.600,5048
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.650,5048
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.700,5048
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.750,5049
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.800,5049
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.850,5050
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.900,5051
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.950,5052
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.975,5053
+2022-02-07,2 wk ahead cum death,2022-02-19,GM11,Brandenburg State,quantile,0.990,5055
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,point,NA,5064
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.010,5053
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.025,5055
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.050,5056
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.100,5057
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.150,5058
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.200,5059
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.250,5060
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.300,5061
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.350,5062
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.400,5062
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.450,5063
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.500,5064
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.550,5065
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.600,5066
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.650,5066
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.700,5067
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.750,5068
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.800,5069
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.850,5071
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.900,5072
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.950,5075
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.975,5077
+2022-02-07,3 wk ahead cum death,2022-02-26,GM11,Brandenburg State,quantile,0.990,5081
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,point,NA,5082
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.010,5064
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.025,5066
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.050,5068
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.100,5071
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.150,5073
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.200,5074
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.250,5076
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.300,5077
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.350,5078
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.400,5079
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.450,5081
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.500,5082
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.550,5083
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.600,5084
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.650,5085
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.700,5087
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.750,5088
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.800,5090
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.850,5092
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.900,5094
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.950,5099
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.975,5103
+2022-02-07,4 wk ahead cum death,2022-03-05,GM11,Brandenburg State,quantile,0.990,5107
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM12,Mecklenburg-Western Pomerania State,observed,NA,24
 2022-02-07,0 wk ahead inc death,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,17
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,18
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,19
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,19
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,20
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,20
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,20
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,20
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,21
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,22
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,23
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,23
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,24
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,24
-2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,25
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,20
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,21
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,22
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,23
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,24
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,25
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,27
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,27
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,29
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,29
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,30
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,31
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,31
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,32
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,34
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,36
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,38
-2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,40
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,35
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,21
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,23
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,26
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,27
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,29
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,30
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,31
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,32
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,33
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,34
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,35
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,35
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,36
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,37
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,39
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,40
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,41
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,43
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,45
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,49
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,52
-2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,56
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,41
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,18
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,22
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,25
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,28
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,31
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,33
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,34
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,36
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,37
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,38
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,40
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,41
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,42
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,43
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,44
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,46
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,47
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,49
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,51
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,55
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,59
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,63
-2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,69
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM12,Mecklenburg-Western Pomerania State,observed,NA,1631
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,14
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,15
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,16
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,17
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,18
+2022-02-07,1 wk ahead inc death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,14
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,25
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,22
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,22
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,24
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,26
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,28
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,32
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,19
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,21
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,23
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,24
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,24
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,25
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,26
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,27
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,29
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,32
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,34
+2022-02-07,4 wk ahead inc death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,38
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM12,Mecklenburg-Western Pomerania State,observed,NA,1631
 2022-02-07,0 wk ahead cum death,2022-02-05,GM12,Mecklenburg-Western Pomerania State,observed,NA,1657
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,1674
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1670
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1671
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1671
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1672
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1673
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1673
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1673
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1673
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1674
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1674
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1674
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1674
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1674
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1675
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1676
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1677
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1678
-2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1678
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,1702
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1688
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1691
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1692
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1695
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1696
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1697
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1698
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1699
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1700
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1701
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1701
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1702
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1703
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1703
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1704
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1705
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1706
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1707
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1708
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1710
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1713
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1715
-2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1718
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,1737
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1707
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1712
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1715
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1720
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1724
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1726
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1728
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1730
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1732
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1733
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1735
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1737
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1738
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1740
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1741
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1743
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1745
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1748
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1751
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1755
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1761
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1767
-2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1774
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,1777
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1726
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1733
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1740
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1748
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1755
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1759
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1762
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1766
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1769
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1771
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1774
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1777
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1780
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1783
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1786
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1789
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1793
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1797
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1802
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1809
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1820
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1830
-2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1843
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM13,Free State of Saxony,observed,NA,119
-2022-02-07,0 wk ahead inc death,2022-02-05,GM13,Free State of Saxony,observed,NA,106
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,point,NA,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.010,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.025,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.050,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.100,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.150,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.200,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.250,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.300,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.350,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.400,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.450,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.500,32
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.550,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.600,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.650,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.700,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.750,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.800,35
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.850,36
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.900,36
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.950,38
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.975,39
-2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.990,41
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,point,NA,50
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,point,NA,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1668
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1668
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1669
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1670
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1671
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1672
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1672
+2022-02-07,1 wk ahead cum death,2022-02-12,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1673
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,point,NA,1689
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1683
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1683
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1684
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1685
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1686
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1686
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1687
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1687
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1687
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1688
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1688
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1689
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1689
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1689
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1690
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1690
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1691
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1691
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1692
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1693
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1695
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1696
+2022-02-07,2 wk ahead cum death,2022-02-19,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1698
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,point,NA,1709
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1697
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1698
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1699
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1701
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1703
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1704
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1704
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1705
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1706
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1707
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1708
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1709
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1710
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1711
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1712
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1713
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1714
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1715
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1716
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1719
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1722
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1725
+2022-02-07,3 wk ahead cum death,2022-02-26,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1730
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,point,NA,1730
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.010,1710
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.025,1712
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.050,1714
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.100,1717
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.150,1719
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.200,1721
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.250,1723
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.300,1724
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.350,1726
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.400,1727
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.450,1729
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.500,1730
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.550,1732
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.600,1734
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.650,1735
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.700,1737
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.750,1739
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.800,1741
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.850,1744
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.900,1748
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.950,1754
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.975,1760
+2022-02-07,4 wk ahead cum death,2022-03-05,GM12,Mecklenburg-Western Pomerania State,quantile,0.990,1768
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM13,Free State of Saxony,observed,NA,117
+2022-02-07,0 wk ahead inc death,2022-02-05,GM13,Free State of Saxony,observed,NA,68
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,point,NA,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.010,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.025,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.050,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.100,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.150,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.200,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.250,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.300,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.350,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.400,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.450,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.500,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.550,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.600,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.650,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.700,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.750,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.800,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.850,39
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.900,40
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.950,41
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.975,42
+2022-02-07,1 wk ahead inc death,2022-02-12,GM13,Free State of Saxony,quantile,0.990,43
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,point,NA,48
 2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.010,33
 2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.025,35
 2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.050,37
 2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.100,40
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.150,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.150,41
 2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.200,43
 2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.250,44
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.300,46
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.350,47
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.400,48
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.450,49
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.500,50
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.550,52
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.600,53
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.650,55
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.700,56
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.750,58
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.800,59
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.850,61
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.900,64
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.950,69
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.975,73
-2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.990,78
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,point,NA,74
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.010,41
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.025,44
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.050,48
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.100,52
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.150,56
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.200,59
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.250,62
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.300,64
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.350,67
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.400,69
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.450,71
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.500,74
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.550,77
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.600,80
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.650,82
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.700,84
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.750,88
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.800,92
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.850,95
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.900,101
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.950,110
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.975,118
-2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.990,128
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,point,NA,98
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.010,48
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.025,53
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.050,58
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.100,66
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.150,71
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.200,75
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.250,80
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.300,84
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.350,87
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.400,91
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.450,94
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.500,98
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.550,102
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.600,106
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.650,110
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.700,114
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.750,118
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.800,123
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.850,128
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.900,136
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.950,146
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.975,155
-2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.990,166
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM13,Free State of Saxony,observed,NA,14031
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.300,45
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.350,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.400,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.450,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.500,48
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.550,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.600,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.650,51
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.700,52
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.750,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.800,54
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.850,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.900,58
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.950,61
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.975,64
+2022-02-07,2 wk ahead inc death,2022-02-19,GM13,Free State of Saxony,quantile,0.990,68
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,point,NA,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.010,34
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.025,38
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.050,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.100,45
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.150,48
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.200,51
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.250,53
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.300,55
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.350,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.400,58
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.450,59
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.500,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.550,62
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.600,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.650,65
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.700,68
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.750,70
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.800,72
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.850,75
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.900,79
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.950,86
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.975,92
+2022-02-07,3 wk ahead inc death,2022-02-26,GM13,Free State of Saxony,quantile,0.990,99
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,point,NA,74
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.010,35
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.025,39
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.050,44
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.100,50
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.150,55
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.200,58
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.250,61
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.300,64
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.350,66
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.400,69
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.450,72
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.500,74
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.550,76
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.600,78
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.650,81
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.700,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.750,87
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.800,91
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.850,95
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.900,101
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.950,112
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.975,121
+2022-02-07,4 wk ahead inc death,2022-03-05,GM13,Free State of Saxony,quantile,0.990,131
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM13,Free State of Saxony,observed,NA,14069
 2022-02-07,0 wk ahead cum death,2022-02-05,GM13,Free State of Saxony,observed,NA,14137
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,point,NA,14146
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.010,14139
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.025,14140
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.050,14141
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.100,14142
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.150,14143
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.200,14143
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.250,14144
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.300,14144
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.350,14145
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.400,14145
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.450,14145
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.500,14146
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.550,14146
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.600,14146
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.650,14147
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.700,14147
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.750,14148
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.800,14148
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.850,14149
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.900,14150
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.950,14151
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.975,14152
-2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.990,14154
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,point,NA,14196
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.010,14173
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.025,14176
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.050,14179
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.100,14182
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.150,14184
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.200,14186
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.250,14188
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.300,14190
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.350,14191
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.400,14193
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.450,14195
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.500,14196
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.550,14198
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.600,14200
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.650,14201
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.700,14203
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.750,14205
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.800,14208
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.850,14210
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.900,14214
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.950,14220
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,point,NA,14156
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.010,14150
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.025,14151
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.050,14152
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.100,14153
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.150,14154
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.200,14154
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.250,14155
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.300,14155
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.350,14155
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.400,14156
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.450,14156
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.500,14156
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.550,14157
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.600,14157
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.650,14157
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.700,14157
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.750,14158
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.800,14158
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.850,14159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.900,14159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.950,14161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.975,14162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM13,Free State of Saxony,quantile,0.990,14163
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,point,NA,14204
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.010,14184
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.025,14187
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.050,14190
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.100,14193
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.150,14195
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.200,14197
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.250,14198
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.300,14200
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.350,14201
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.400,14202
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.450,14203
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.500,14204
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.550,14206
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.600,14206
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.650,14208
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.700,14209
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.750,14211
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.800,14212
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.850,14214
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.900,14217
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.950,14222
 2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.975,14225
-2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.990,14232
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,point,NA,14270
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.010,14214
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.025,14220
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.050,14226
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.100,14234
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.150,14240
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.200,14245
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.250,14250
+2022-02-07,2 wk ahead cum death,2022-02-19,GM13,Free State of Saxony,quantile,0.990,14231
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,point,NA,14266
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.010,14218
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.025,14225
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.050,14231
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.100,14238
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.150,14244
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.200,14247
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.250,14251
 2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.300,14254
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.350,14258
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.400,14262
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.450,14266
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.500,14270
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.550,14275
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.600,14279
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.650,14283
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.700,14287
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.750,14293
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.800,14299
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.850,14305
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.900,14315
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.950,14329
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.975,14343
-2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.990,14359
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,point,NA,14368
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.010,14262
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.025,14274
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.050,14285
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.100,14300
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.150,14312
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.200,14321
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.250,14330
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.300,14338
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.350,14345
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.400,14353
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.450,14361
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.500,14368
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.550,14378
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.600,14386
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.650,14393
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.700,14401
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.750,14411
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.800,14422
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.850,14434
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.900,14450
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.950,14476
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.975,14498
-2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.990,14524
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,56
-2022-02-07,0 wk ahead inc death,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,48
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,89
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,80
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,82
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,83
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,84
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,85
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,85
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,86
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,87
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,87
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,88
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,89
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,89
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,90
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,90
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,91
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,92
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,93
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,94
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,95
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,97
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,100
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,102
-2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,106
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,148
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,125
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,127
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,130
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,133
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,135
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,137
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,138
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,140
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.350,14257
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.400,14260
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.450,14263
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.500,14266
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.550,14268
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.600,14270
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.650,14273
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.700,14277
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.750,14280
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.800,14284
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.850,14288
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.900,14296
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.950,14308
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.975,14317
+2022-02-07,3 wk ahead cum death,2022-02-26,GM13,Free State of Saxony,quantile,0.990,14330
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,point,NA,14340
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.010,14253
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.025,14264
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.050,14275
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.100,14289
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.150,14299
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.200,14306
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.250,14312
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.300,14318
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.350,14324
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.400,14329
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.450,14335
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.500,14340
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.550,14344
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.600,14349
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.650,14354
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.700,14360
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.750,14368
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.800,14375
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.850,14383
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.900,14397
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.950,14419
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.975,14438
+2022-02-07,4 wk ahead cum death,2022-03-05,GM13,Free State of Saxony,quantile,0.990,14461
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM14,Sachsen-Anhalt State,observed,NA,57
+2022-02-07,0 wk ahead inc death,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,86
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,78
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,79
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,80
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,82
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,83
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,84
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,84
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,85
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,85
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,85
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,86
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,86
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,86
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,87
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,88
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,88
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,89
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,89
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,90
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,92
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,94
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,96
+2022-02-07,1 wk ahead inc death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,99
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,146
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,126
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,128
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,132
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,135
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,138
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,140
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,141
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,142
 2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,143
 2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,144
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,146
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,148
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,150
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,151
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,153
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,156
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,159
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,163
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,167
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,173
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,183
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,192
-2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,205
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,223
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,181
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,185
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,190
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,195
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,199
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,202
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,205
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,209
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,214
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,216
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,220
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,223
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,227
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,230
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,145
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,146
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,147
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,148
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,150
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,152
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,153
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,156
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,158
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,163
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,170
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,178
+2022-02-07,2 wk ahead inc death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,189
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,228
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,190
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,194
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,202
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,207
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,212
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,216
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,217
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,219
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,221
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,224
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,226
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,228
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,230
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,232
 2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,235
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,241
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,247
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,253
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,262
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,273
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,293
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,310
-2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,334
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,298
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,239
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,246
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,251
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,259
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,264
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,268
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,272
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,279
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,285
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,288
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,294
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,298
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,303
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,308
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,314
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,323
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,330
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,338
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,238
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,242
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,247
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,252
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,263
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,276
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,292
+2022-02-07,3 wk ahead inc death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,314
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,315
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,261
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,269
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,278
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,286
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,294
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,297
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,300
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,303
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,306
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,309
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,312
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,315
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,318
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,321
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,325
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,329
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,334
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,341
 2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,349
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,364
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,385
-2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,405
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,363
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,381
+2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,401
 2022-02-07,4 wk ahead inc death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,426
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM14,Sachsen-Anhalt State,observed,NA,4580
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM14,Sachsen-Anhalt State,observed,NA,4590
 2022-02-07,0 wk ahead cum death,2022-02-05,GM14,Sachsen-Anhalt State,observed,NA,4628
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,4721
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,4710
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,4712
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,4713
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,4715
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,4716
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,4717
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,4718
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,point,NA,4719
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.010,4708
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.025,4710
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.050,4712
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.100,4714
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.150,4715
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.200,4716
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.250,4717
 2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.300,4718
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,4719
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,4720
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,4721
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,4721
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,4722
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,4722
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,4723
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,4724
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,4725
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,4726
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,4727
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,4729
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,4731
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,4734
-2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,4737
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,4869
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.350,4718
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.400,4718
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.450,4719
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.500,4719
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.550,4720
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.600,4720
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.650,4721
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.700,4722
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.750,4722
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.800,4723
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.850,4724
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.900,4726
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.950,4728
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.975,4730
+2022-02-07,1 wk ahead cum death,2022-02-12,GM14,Sachsen-Anhalt State,quantile,0.990,4733
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,point,NA,4866
 2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.010,4834
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,4840
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,4843
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,4848
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,4851
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,4854
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,4856
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,4859
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,4862
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,4864
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,4867
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,4869
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,4871
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,4874
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,4876
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,4879
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,4883
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,4888
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,4894
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,4902
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,4914
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,4926
-2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,4942
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,5093
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,5016
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,5025
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,5034
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,5043
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,5050
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,5057
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,5061
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,5069
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,5076
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,5081
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,5087
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,5093
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.025,4839
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.050,4844
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.100,4849
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.150,4852
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.200,4857
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.250,4858
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.300,4860
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.350,4861
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.400,4862
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.450,4864
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.500,4866
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.550,4867
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.600,4869
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.650,4871
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.700,4873
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.750,4876
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.800,4879
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.850,4882
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.900,4888
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.950,4898
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.975,4907
+2022-02-07,2 wk ahead cum death,2022-02-19,GM14,Sachsen-Anhalt State,quantile,0.990,4921
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,point,NA,5094
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.010,5026
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.025,5033
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.050,5046
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.100,5057
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.150,5065
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.200,5072
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.250,5075
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.300,5079
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.350,5082
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.400,5086
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.450,5091
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.500,5094
 2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.550,5098
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,5104
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,5111
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,5120
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,5130
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,5141
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,5154
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,5174
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,5207
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,5236
-2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,5276
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,5391
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,5256
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,5272
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,5286
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,5302
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,5315
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,5325
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,5333
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,5348
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,5361
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,5369
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,5381
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,5391
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,5402
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,5411
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,5425
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,5442
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,5459
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,5479
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,5504
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,5536
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,5591
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,5640
-2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,5701
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM15,Free State of Thuringia,observed,NA,54
-2022-02-07,0 wk ahead inc death,2022-02-05,GM15,Free State of Thuringia,observed,NA,58
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,point,NA,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,8
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,8
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,8
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,8
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,8
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,8
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,9
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,10
-2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,10
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,point,NA,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,3
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,4
-2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,4
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,point,NA,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,1
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,2
-2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,2
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,point,NA,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,0
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,1
-2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,1
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM15,Free State of Thuringia,observed,NA,6388
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.600,5100
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.650,5106
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.700,5112
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.750,5118
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.800,5125
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.850,5135
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.900,5150
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.950,5173
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.975,5197
+2022-02-07,3 wk ahead cum death,2022-02-26,GM14,Sachsen-Anhalt State,quantile,0.990,5234
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,point,NA,5410
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.010,5287
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.025,5301
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.050,5324
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.100,5341
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.150,5357
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.200,5369
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.250,5374
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.300,5383
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.350,5389
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.400,5395
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.450,5402
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.500,5410
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.550,5415
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.600,5422
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.650,5432
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.700,5441
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.750,5451
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.800,5467
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.850,5485
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.900,5513
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.950,5554
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.975,5598
+2022-02-07,4 wk ahead cum death,2022-03-05,GM14,Sachsen-Anhalt State,quantile,0.990,5659
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM15,Free State of Thuringia,observed,NA,53
+2022-02-07,0 wk ahead inc death,2022-02-05,GM15,Free State of Thuringia,observed,NA,52
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,point,NA,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,29
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,30
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,31
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,32
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,33
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,34
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,35
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,36
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,37
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,38
+2022-02-07,1 wk ahead inc death,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,40
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,point,NA,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,35
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,37
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,38
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,39
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,41
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,42
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,43
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,44
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,45
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,45
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,46
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,47
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,48
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,49
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,50
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,52
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,53
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,55
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,57
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,60
+2022-02-07,2 wk ahead inc death,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,64
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,point,NA,59
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,41
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,43
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,45
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,47
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,49
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,51
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,52
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,54
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,55
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,56
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,57
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,59
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,60
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,61
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,63
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,65
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,66
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,68
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,71
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,74
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,78
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,82
+2022-02-07,3 wk ahead inc death,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,88
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,point,NA,69
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,45
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,48
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,50
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,53
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,56
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,58
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,60
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,62
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,64
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,65
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,67
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,69
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,70
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,72
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,74
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,76
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,78
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,81
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,84
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,87
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,92
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,97
+2022-02-07,4 wk ahead inc death,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,102
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM15,Free State of Thuringia,observed,NA,6394
 2022-02-07,0 wk ahead cum death,2022-02-05,GM15,Free State of Thuringia,observed,NA,6446
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,point,NA,6437
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,6433
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,6433
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,6434
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,6434
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,6434
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,6435
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,6435
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,6435
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,6436
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,6436
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,6436
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,6437
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,6437
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,6437
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,6438
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,6438
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,6439
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,6439
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,6439
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,6440
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,6440
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,6440
-2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,6440
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,point,NA,6440
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,6436
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,6436
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,6437
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,6437
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,6437
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,6438
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,6438
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,6439
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,6439
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,6440
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,6440
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,6440
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,6441
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,6441
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,6442
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,6442
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,6442
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,6443
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,6443
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,6444
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,6444
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,6444
-2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,6444
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,point,NA,6442
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,6437
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,6438
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,6438
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,6438
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,6439
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,6439
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,6440
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,6440
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,6440
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,6441
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,6441
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,6442
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,6442
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,6443
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,6443
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,6444
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,6444
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,6444
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,6445
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,6445
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,6446
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,6446
-2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,6446
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,point,NA,6442
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,6438
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,6438
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,6438
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,6439
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,6439
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,6440
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,6440
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,6440
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,6441
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,6441
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,6442
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,6442
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,6443
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,6443
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,6444
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,6444
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,6445
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,6445
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,6446
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,6446
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,6446
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,6447
-2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,6447
-2022-02-07,-1 wk ahead inc death,2022-01-28,GM16,Berlin State,observed,NA,21
-2022-02-07,0 wk ahead inc death,2022-02-05,GM16,Berlin State,observed,NA,37
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,point,NA,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.010,23
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.025,24
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.050,25
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.100,25
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.150,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.200,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.250,26
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.300,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.350,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.400,27
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.450,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.500,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.550,28
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.600,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.650,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.700,29
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.750,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.800,30
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.850,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.900,31
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.950,33
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.975,34
-2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.990,35
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,point,NA,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.010,18
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.025,19
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.050,20
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.100,22
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.150,22
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.200,23
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.250,24
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.300,24
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.350,25
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.400,25
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.450,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.500,26
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.550,27
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.600,27
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.650,28
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.700,29
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.750,30
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.800,30
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.850,32
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.900,33
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.950,36
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.975,38
-2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.990,41
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,point,NA,24
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.010,14
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.025,15
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.050,16
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.100,18
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.150,18
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.200,19
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.250,20
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.300,21
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.350,21
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.400,22
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.450,23
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.500,24
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.550,24
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.600,25
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.650,26
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.700,27
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.750,28
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.800,29
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.850,31
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.900,33
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.950,37
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.975,40
-2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.990,45
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,point,NA,21
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.010,10
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.025,12
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.050,13
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.100,14
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.150,15
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.200,16
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.250,17
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.300,17
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.350,18
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.400,19
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.450,20
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.500,21
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.550,21
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.600,22
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.650,23
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.700,25
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.750,26
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.800,27
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.850,29
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.900,32
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.950,36
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.975,40
-2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.990,45
-2022-02-07,-1 wk ahead cum death,2022-01-28,GM16,Berlin State,observed,NA,4098
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,point,NA,6469
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.010,6465
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.025,6466
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.050,6466
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.100,6467
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.150,6467
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.200,6468
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.250,6468
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.300,6468
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.350,6469
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.400,6469
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.450,6469
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.500,6469
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.550,6470
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.600,6470
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.650,6470
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.700,6471
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.750,6471
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.800,6471
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.850,6472
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.900,6472
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.950,6473
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.975,6474
+2022-02-07,1 wk ahead cum death,2022-02-12,GM15,Free State of Thuringia,quantile,0.990,6475
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,point,NA,6515
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.010,6501
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.025,6503
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.050,6504
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.100,6507
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.150,6508
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.200,6509
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.250,6511
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.300,6512
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.350,6512
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.400,6513
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.450,6514
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.500,6515
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.550,6517
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.600,6518
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.650,6519
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.700,6520
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.750,6521
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.800,6523
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.850,6525
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.900,6527
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.950,6531
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.975,6534
+2022-02-07,2 wk ahead cum death,2022-02-19,GM15,Free State of Thuringia,quantile,0.990,6539
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,point,NA,6574
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.010,6542
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.025,6546
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.050,6550
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.100,6554
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.150,6557
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.200,6560
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.250,6563
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.300,6565
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.350,6567
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.400,6569
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.450,6572
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.500,6574
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.550,6576
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.600,6579
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.650,6582
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.700,6585
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.750,6588
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.800,6591
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.850,6595
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.900,6600
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.950,6609
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.975,6616
+2022-02-07,3 wk ahead cum death,2022-02-26,GM15,Free State of Thuringia,quantile,0.990,6627
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,point,NA,6643
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.010,6586
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.025,6593
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.050,6600
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.100,6607
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.150,6613
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.200,6618
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.250,6623
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.300,6627
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.350,6631
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.400,6634
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.450,6638
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.500,6643
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.550,6646
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.600,6651
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.650,6656
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.700,6661
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.750,6666
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.800,6672
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.850,6679
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.900,6688
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.950,6701
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.975,6712
+2022-02-07,4 wk ahead cum death,2022-03-05,GM15,Free State of Thuringia,quantile,0.990,6729
+2022-02-07,-1 wk ahead inc death,2022-01-29,GM16,Berlin State,observed,NA,25
+2022-02-07,0 wk ahead inc death,2022-02-05,GM16,Berlin State,observed,NA,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,point,NA,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.010,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.025,21
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.050,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.100,22
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.150,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.200,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.250,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.300,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.350,23
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.400,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.450,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.500,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.550,24
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.600,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.650,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.700,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.750,25
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.800,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.850,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.900,26
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.950,27
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.975,28
+2022-02-07,1 wk ahead inc death,2022-02-12,GM16,Berlin State,quantile,0.990,29
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,point,NA,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.010,15
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.025,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.050,16
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.100,17
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.150,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.200,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.250,18
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.300,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.350,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.400,19
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.450,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.500,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.550,20
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.600,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.650,21
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.700,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.750,22
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.800,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.850,23
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.900,24
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.950,25
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.975,27
+2022-02-07,2 wk ahead inc death,2022-02-19,GM16,Berlin State,quantile,0.990,29
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,point,NA,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.010,10
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.025,11
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.050,12
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.100,13
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.150,13
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.200,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.250,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.300,14
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.350,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.400,15
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.450,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.500,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.550,16
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.600,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.650,17
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.700,18
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.750,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.800,19
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.850,20
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.900,21
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.950,23
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.975,25
+2022-02-07,3 wk ahead inc death,2022-02-26,GM16,Berlin State,quantile,0.990,27
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,point,NA,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.010,7
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.025,8
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.050,8
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.100,9
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.150,10
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.200,10
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.250,11
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.300,11
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.350,11
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.400,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.450,12
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.500,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.550,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.600,13
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.650,14
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.700,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.750,15
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.800,16
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.850,17
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.900,18
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.950,20
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.975,22
+2022-02-07,4 wk ahead inc death,2022-03-05,GM16,Berlin State,quantile,0.990,25
+2022-02-07,-1 wk ahead cum death,2022-01-29,GM16,Berlin State,observed,NA,4107
 2022-02-07,0 wk ahead cum death,2022-02-05,GM16,Berlin State,observed,NA,4135
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,point,NA,4163
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.010,4158
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.025,4159
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.050,4159
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.100,4160
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.150,4161
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.200,4161
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.250,4162
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.300,4162
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.350,4162
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.400,4163
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.450,4163
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.500,4163
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.550,4164
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.600,4164
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.650,4164
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.700,4164
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.750,4165
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.800,4165
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.850,4166
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.900,4167
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.950,4168
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.975,4169
-2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.990,4170
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,point,NA,4189
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.010,4177
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.025,4179
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.050,4180
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.100,4182
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.150,4183
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.200,4184
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.250,4185
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.300,4186
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.350,4187
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.400,4188
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.450,4189
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.500,4189
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.550,4190
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.600,4191
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.650,4192
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.700,4193
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.750,4194
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.800,4196
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.850,4198
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.900,4200
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.950,4203
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.975,4207
-2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.990,4211
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,point,NA,4213
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.010,4191
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.025,4194
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.050,4196
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.100,4199
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.150,4202
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.200,4203
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.250,4205
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.300,4207
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.350,4208
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.400,4210
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.450,4211
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.500,4213
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.550,4215
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.600,4216
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.650,4218
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.700,4220
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.750,4222
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.800,4225
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.850,4229
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.900,4233
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.950,4240
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.975,4246
-2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.990,4255
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,point,NA,4233
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.010,4201
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.025,4205
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.050,4209
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.100,4214
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.150,4216
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.200,4219
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.250,4222
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.300,4224
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.350,4226
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.400,4229
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.450,4231
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.500,4233
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.550,4236
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.600,4239
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.650,4242
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.700,4245
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.750,4248
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.800,4252
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.850,4258
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.900,4264
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.950,4275
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.975,4286
-2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.990,4300
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,point,NA,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.010,4157
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.025,4157
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.050,4158
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.100,4159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.150,4159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.200,4159
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.250,4160
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.300,4160
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.350,4160
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.400,4160
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.450,4160
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.500,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.550,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.600,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.650,4161
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.700,4162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.750,4162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.800,4162
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.850,4163
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.900,4163
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.950,4164
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.975,4164
+2022-02-07,1 wk ahead cum death,2022-02-12,GM16,Berlin State,quantile,0.990,4165
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,point,NA,4181
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.010,4172
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.025,4173
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.050,4174
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.100,4176
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.150,4177
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.200,4177
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.250,4178
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.300,4179
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.350,4179
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.400,4180
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.450,4180
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.500,4181
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.550,4181
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.600,4182
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.650,4182
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.700,4183
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.750,4184
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.800,4185
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.850,4186
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.900,4187
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.950,4189
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.975,4191
+2022-02-07,2 wk ahead cum death,2022-02-19,GM16,Berlin State,quantile,0.990,4193
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,point,NA,4197
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.010,4182
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.025,4184
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.050,4186
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.100,4189
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.150,4190
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.200,4191
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.250,4192
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.300,4193
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.350,4194
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.400,4195
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.450,4196
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.500,4197
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.550,4198
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.600,4199
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.650,4200
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.700,4201
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.750,4202
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.800,4204
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.850,4206
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.900,4208
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.950,4212
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.975,4216
+2022-02-07,3 wk ahead cum death,2022-02-26,GM16,Berlin State,quantile,0.990,4221
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,point,NA,4210
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.010,4189
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.025,4192
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.050,4195
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.100,4198
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.150,4200
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.200,4201
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.250,4203
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.300,4204
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.350,4205
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.400,4207
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.450,4208
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.500,4210
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.550,4211
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.600,4212
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.650,4214
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.700,4216
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.750,4218
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.800,4220
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.850,4223
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.900,4226
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.950,4232
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.975,4238
+2022-02-07,4 wk ahead cum death,2022-03-05,GM16,Berlin State,quantile,0.990,4246


### PR DESCRIPTION
Note, prediction for Baden-Württemberg (GM01), Saarland (GM09), and Thuringia (GM15) are broken.